### PR TITLE
DKE - Added navX MXP IMU for field oriented driving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@
 *.app
 RecycleRushBot/.settings/language.settings.xml
 RecycleRushBot/Debug/FRCUserProgram
+RecycleRushBot/.settings/language.settings.xml

--- a/RecycleRushBot/.settings/language.settings.xml
+++ b/RecycleRushBot/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="false" env-hash="-1677850494092983520" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="false" env-hash="711777043677794338" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/RecycleRushBot/CPP/IMU.cpp
+++ b/RecycleRushBot/CPP/IMU.cpp
@@ -1,0 +1,370 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) Kauai Labs. All Rights Reserved.							  */
+/*                                                                            */
+/* Created in support of Team 2465 (Kauaibots).  Go Thunderchicken!           */
+/*                                                                            */
+/* Based upon the Open Source WPI Library released by FIRST robotics.         */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in $(WIND_BASE)/WPILib.  */
+/*----------------------------------------------------------------------------*/
+
+#include "NetworkCommunication/UsageReporting.h"
+#include "Timer.h"
+#include "WPIErrors.h"
+#include "LiveWindow/LiveWindow.h"
+#include <time.h>
+#include "../H/IMU.h"
+#include "../H/IMUProtocol.h"
+#include <string.h>
+
+//static SEM_ID cIMUStateSemaphore = semBCreate (SEM_Q_PRIORITY, SEM_FULL);
+static ReentrantSemaphore cIMUStateSemaphore;
+static int update_count = 0;
+static int byte_count = 0;
+
+static bool stop = false;
+
+/*** Internal task.
+ * 
+ * Task which retrieves yaw/pitch/roll updates from the IMU, via the
+ * SerialPort.
+ **/ 
+
+static char protocol_buffer[1024];
+
+static void imuTask(IMU *imu) 
+{
+    bool stream_response_received = false;
+    double last_stream_command_sent_timestamp = 0.0;
+	stop = false;
+	SerialPort *pport = imu->GetSerialPort();
+	pport->SetReadBufferSize(512);
+	pport->SetTimeout(1.0);
+	pport->EnableTermination('\n');
+	pport->Flush();
+	pport->Reset();
+
+	char stream_type;
+	uint16_t gyro_fsr_dps, accel_fsr, update_rate_hz;
+	uint16_t q1_offset, q2_offset, q3_offset, q4_offset;
+	float yaw_offset_degrees;
+	uint16_t flags;
+	
+    // Give the nav6 circuit a few seconds to initialize, then send the stream configuration command.
+    int cmd_packet_length = IMUProtocol::encodeStreamCommand( protocol_buffer, imu->current_stream_type, imu->update_rate_hz ); 
+    pport->Reset();
+    pport->Write( protocol_buffer, cmd_packet_length );
+    pport->Flush();
+    last_stream_command_sent_timestamp = Timer::GetFPGATimestamp();
+		
+	while (!stop)
+	{ 
+		uint32_t bytes_read = pport->Read( protocol_buffer, 256 );
+		if ( bytes_read > 0 )
+		{
+			int packets_received = 0;
+			byte_count += bytes_read;
+			uint32_t i = 0;
+			// Scan the buffer looking for valid packets
+			while ( i < bytes_read )
+			{
+				int bytes_remaining = bytes_read - i;
+				int packet_length = imu->DecodePacketHandler( &protocol_buffer[i], bytes_remaining ); 
+				if ( packet_length > 0 )
+				{
+					packets_received++;
+					update_count++;
+					i += packet_length;
+				}
+				else 
+				{
+					packet_length = IMUProtocol::decodeStreamResponse( &protocol_buffer[i], bytes_remaining, stream_type,
+							  gyro_fsr_dps, accel_fsr, update_rate_hz,
+							  yaw_offset_degrees, 
+							  q1_offset, q2_offset, q3_offset, q4_offset,
+							  flags );
+					if ( packet_length > 0 ) 
+					{
+						packets_received++;
+						imu->SetStreamResponse( stream_type, 
+								  gyro_fsr_dps, accel_fsr, update_rate_hz,
+								  yaw_offset_degrees, 
+								  q1_offset, q2_offset, q3_offset, q4_offset,
+								  flags );
+						stream_response_received = true;
+						i += packet_length;
+					}
+					else // current index is not the start of a valid packet we're interested in; increment
+					{
+						i++;
+					}
+				}
+			}
+			if ( ( packets_received == 0 ) && ( bytes_read == 256 ) ) {
+				// No packets received and 256 bytes received; this
+				// condition occurs in the SerialPort.  In this case,
+				// reset the serial port.
+				pport->Reset();
+			}
+			
+			if ( !stream_response_received && ((Timer::GetFPGATimestamp() - last_stream_command_sent_timestamp ) > 3.0 ) ) {
+				cmd_packet_length = IMUProtocol::encodeStreamCommand( protocol_buffer, imu->current_stream_type, imu->update_rate_hz ); 
+				last_stream_command_sent_timestamp = Timer::GetFPGATimestamp();
+				pport->Write( protocol_buffer, cmd_packet_length );
+				pport->Flush();
+			}	            				
+		}
+		else {
+			// This exception typically indicates a Timeout
+			stream_response_received = false;
+		}
+	}
+}
+
+int IMU::DecodePacketHandler( char *received_data, int bytes_remaining ) {
+	
+	float yaw = 0.0;
+	float pitch = 0.0;
+	float roll = 0.0;
+	float compass_heading = 0.0;		
+
+	int packet_length = IMUProtocol::decodeYPRUpdate( received_data, bytes_remaining, yaw, pitch, roll, compass_heading ); 
+	if ( packet_length > 0 )
+	{
+		SetYawPitchRoll(yaw,pitch,roll,compass_heading);
+	}
+	return packet_length;
+}
+
+void IMU::InternalInit( SerialPort *pport, uint8_t update_rate_hz, char stream_type ) {
+	current_stream_type = stream_type;
+	yaw_offset_degrees = 0;
+	accel_fsr_g = 2;
+	gyro_fsr_dps = 2000;
+	flags = 0;
+	this->update_rate_hz = update_rate_hz;
+	m_task = new Task("IMU", (FUNCPTR)imuTask,Task::kDefaultPriority+1);
+	yaw = 0.0;
+	pitch = 0.0;
+	roll = 0.0;
+	pserial_port = pport;
+	pserial_port->Reset();
+	InitIMU();
+	m_task->Start((uint32_t)this);
+}
+
+IMU::IMU( SerialPort *pport, uint8_t update_rate_hz, char stream_type ) {
+	InternalInit(pport,update_rate_hz,stream_type);
+}
+
+IMU::IMU( SerialPort *pport, uint8_t update_rate_hz )
+{
+	InternalInit(pport,update_rate_hz,STREAM_CMD_STREAM_TYPE_YPR);
+}
+
+/**
+ * Initialize the IMU.
+ */
+void IMU::InitIMU()
+{
+	// The IMU serial port configuration is 8 data bits, no parity, one stop bit. 
+	// No flow control is used.
+	// Conveniently, these are the defaults used by the WPILib's SerialPort class.
+	//
+	// In addition, the WPILib's SerialPort class also defaults to:
+	//
+	// Timeout period of 5 seconds
+	// Termination ('\n' character)
+	// Transmit immediately
+	InitializeYawHistory();
+	yaw_offset = 0;
+	
+	// set the nav6 into "YPR" update mode
+	
+	int packet_length = IMUProtocol::encodeStreamCommand( protocol_buffer, current_stream_type, update_rate_hz ); 
+	pserial_port->Write( protocol_buffer, packet_length );	
+}
+
+/**
+ * Delete the IMU.
+ */
+IMU::~IMU()
+{
+	m_task->Stop();
+	delete m_task;
+	m_task = 0;
+}
+
+void IMU::Restart()
+{
+	stop = true;
+	pserial_port->Reset();
+	m_task->Stop();
+	
+	pserial_port->Reset();
+	InitializeYawHistory();
+	update_count = 0;
+	byte_count = 0;
+	m_task->Restart();
+}
+
+bool IMU::IsConnected()
+{
+	double time_since_last_update = Timer::GetFPGATimestamp() - this->last_update_time;
+	return time_since_last_update <= 1.0;
+}
+
+double IMU::GetByteCount()
+{
+	return byte_count;
+}
+double IMU::GetUpdateCount()
+{
+	return update_count;
+}
+
+bool IMU::IsCalibrating()
+{
+	Synchronized sync(cIMUStateSemaphore);
+	uint16_t calibration_state = this->flags & NAV6_FLAG_MASK_CALIBRATION_STATE;
+	return (calibration_state != NAV6_CALIBRATION_STATE_COMPLETE);
+}
+
+void IMU::ZeroYaw()
+{
+	yaw_offset = GetAverageFromYawHistory();
+}
+
+
+/**
+ * Return the yaw angle in degrees.
+ * 
+ * This angle increases as the robot spins to the right.
+ * 
+ * This angle ranges from -180 to 180 degrees.
+ */
+float IMU::GetYaw( void )
+{
+	Synchronized sync(cIMUStateSemaphore);
+	double yaw = this->yaw;
+	yaw -= yaw_offset;
+	if ( yaw < -180 ) yaw += 360;
+	if ( yaw > 180 ) yaw -= 360;
+	return yaw;
+}
+
+float IMU::GetPitch( void )
+{
+	Synchronized sync(cIMUStateSemaphore);
+	return this->pitch;
+}
+
+float IMU::GetRoll( void )
+{
+	Synchronized sync(cIMUStateSemaphore);
+	return this->roll;
+}
+
+float IMU::GetCompassHeading( void )
+{
+	Synchronized sync(cIMUStateSemaphore);
+	return this->compass_heading;
+}
+
+/**
+ * Get the angle in degrees for the PIDSource base object.
+ * 
+ * @return The angle in degrees.
+ */
+double IMU::PIDGet()
+{
+	return GetYaw();
+}
+
+void IMU::UpdateTable() {
+	if (m_table != NULL) {
+		m_table->PutNumber("Value", GetYaw());
+	}
+}
+
+void IMU::StartLiveWindowMode() {
+	
+}
+
+void IMU::StopLiveWindowMode() {
+	
+}
+
+std::string IMU::GetSmartDashboardType() {
+	return "Gyro";
+}
+
+void IMU::InitTable(ITable *subTable) {
+	m_table = subTable;
+	UpdateTable();
+}
+
+ITable * IMU::GetTable() {
+	return m_table;
+}
+
+void IMU::SetYawPitchRoll(float yaw, float pitch, float roll, float compass_heading)
+{
+	{
+		Synchronized sync(cIMUStateSemaphore);
+		
+		this->yaw = yaw;
+		this->pitch = pitch;
+		this->roll = roll;
+		this->compass_heading = compass_heading;
+	}
+	UpdateYawHistory(this->yaw);
+}
+
+void IMU::InitializeYawHistory()
+{
+	memset(yaw_history,0,sizeof(yaw_history));
+	next_yaw_history_index = 0;
+	last_update_time = 0.0;
+}
+
+void IMU::UpdateYawHistory(float curr_yaw )
+{
+	if ( next_yaw_history_index >= YAW_HISTORY_LENGTH )
+	{
+		next_yaw_history_index = 0;
+	}
+	yaw_history[next_yaw_history_index] = curr_yaw;
+	last_update_time = Timer::GetFPGATimestamp();
+	next_yaw_history_index++;
+}
+
+double IMU::GetAverageFromYawHistory()
+{
+	Synchronized sync(cIMUStateSemaphore);
+	double yaw_history_sum = 0.0;
+	for ( int i = 0; i < YAW_HISTORY_LENGTH; i++ )
+	{
+		yaw_history_sum += yaw_history[i];
+	}	
+	double yaw_history_avg = yaw_history_sum / YAW_HISTORY_LENGTH;
+	return yaw_history_avg;
+}
+
+void IMU::SetStreamResponse( char stream_type, 
+								uint16_t gyro_fsr_dps, uint16_t accel_fsr, uint16_t update_rate_hz,
+								float yaw_offset_degrees, 
+								uint16_t q1_offset, uint16_t q2_offset, uint16_t q3_offset, uint16_t q4_offset,
+								uint16_t flags )
+{
+	{
+		Synchronized sync(cIMUStateSemaphore);
+		this->yaw_offset_degrees = yaw_offset_degrees;
+		this->flags = flags;
+		this->accel_fsr_g = accel_fsr;
+		this->gyro_fsr_dps = gyro_fsr_dps;
+		this->update_rate_hz = update_rate_hz;
+	}		
+}
+
+

--- a/RecycleRushBot/CPP/IMUAdvanced.cpp
+++ b/RecycleRushBot/CPP/IMUAdvanced.cpp
@@ -1,0 +1,256 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) Kauai Labs. All Rights Reserved.							  */
+/*                                                                            */
+/* Created in support of Team 2465 (Kauaibots).  Go Thunderchicken!           */
+/*                                                                            */
+/* Based upon the Open Source WPI Library released by FIRST robotics.         */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in $(WIND_BASE)/WPILib.  */
+/*----------------------------------------------------------------------------*/
+
+#include "NetworkCommunication/UsageReporting.h"
+#include "Timer.h"
+#include "WPIErrors.h"
+#include "LiveWindow/LiveWindow.h"
+#include <time.h>
+#include "../H/IMUAdvanced.h"
+#include "../H/IMUProtocol.h"
+#include <math.h>
+#include <string.h>
+
+int IMUAdvanced::DecodePacketHandler( char *received_data, int bytes_remaining ) {
+	
+	int16_t q1, q2, q3, q4;
+	int16_t accel_x, accel_y, accel_z;
+	int16_t mag_x, mag_y, mag_z;
+	float temp_c;
+
+	int packet_length = IMUProtocol::decodeQuaternionUpdate( received_data, bytes_remaining, 
+			q1,q2,q3,q4,accel_x,accel_y,accel_z,mag_x,mag_y,mag_z,temp_c ); 
+	if ( packet_length > 0 ) {
+		SetQuaternion(q1,q2,q3,q4,accel_x,accel_y,accel_z,mag_x,mag_y,mag_z,temp_c);
+	}
+	return packet_length;
+}
+
+IMUAdvanced::IMUAdvanced( SerialPort *pport, uint8_t update_rate_hz ) :
+	IMU(pport,update_rate_hz,STREAM_CMD_STREAM_TYPE_QUATERNION)
+{
+	InitWorldLinearAccelHistory();
+}
+
+IMUAdvanced::~IMUAdvanced() {
+	
+}
+
+void IMUAdvanced::InitWorldLinearAccelHistory()
+{
+	memset(world_linear_accel_history,0,sizeof(world_linear_accel_history));
+	next_world_linear_accel_history_index = 0;
+	world_linear_acceleration_recent_avg = 0.0;	
+}
+
+void IMUAdvanced::UpdateWorldLinearAccelHistory( float x, float y, float z )
+{
+	if ( next_world_linear_accel_history_index >= WORLD_LINEAR_ACCEL_HISTORY_LENGTH )
+	{
+		next_world_linear_accel_history_index = 0;
+	}
+	world_linear_accel_history[next_world_linear_accel_history_index] = fabs(x) + fabs(y);
+	next_world_linear_accel_history_index++;
+}
+
+float IMUAdvanced::GetAverageFromWorldLinearAccelHistory()
+{
+	float world_linear_accel_history_avg = 0.0;
+	for ( int i = 0; i < WORLD_LINEAR_ACCEL_HISTORY_LENGTH; i++ )
+	{
+		world_linear_accel_history_avg += world_linear_accel_history[i];
+	}
+	world_linear_accel_history_avg /= WORLD_LINEAR_ACCEL_HISTORY_LENGTH;
+	return world_linear_accel_history_avg;
+}
+
+float IMUAdvanced::GetWorldLinearAccelX()
+{
+	return this->world_linear_accel_x;
+}
+
+float IMUAdvanced::GetWorldLinearAccelY()
+{
+	return this->world_linear_accel_y;	
+}
+
+float IMUAdvanced::GetWorldLinearAccelZ()
+{
+	return this->world_linear_accel_z;	
+}
+
+bool  IMUAdvanced::IsMoving()
+{
+	return (GetAverageFromWorldLinearAccelHistory() >= 0.01);
+}
+
+float IMUAdvanced::GetTempC()
+{
+	return this->temp_c;
+}
+
+void IMUAdvanced::SetQuaternion( int16_t quat1, int16_t quat2, int16_t quat3, int16_t quat4,
+					int16_t accel_x, int16_t accel_y, int16_t accel_z,
+					int16_t mag_x, int16_t mag_y, int16_t mag_z,
+					float temp_c)
+{
+	{
+		float q[4];				// Quaternion from IMU
+		float gravity[3];		// Gravity Vector
+		//float euler[3];			// Classic euler angle representation of quaternion
+		float ypr[3];			// Angles in "Tait-Bryan" (yaw/pitch/roll) format
+		float yaw_degrees;
+		float pitch_degrees;
+		float roll_degrees;
+		float linear_acceleration_x;
+		float linear_acceleration_y;
+		float linear_acceleration_z;
+        float q2[4];
+        float q_product[4];
+		float world_linear_acceleration_x;
+		float world_linear_acceleration_y;
+		float world_linear_acceleration_z;
+        
+		// Convert 15-bit signed quaternion integral values to floats
+		q[0] = ((float)quat1) / 16384.0f;
+		q[1] = ((float)quat2) / 16384.0f;
+		q[2] = ((float)quat3) / 16384.0f;
+        q[3] = ((float)quat4) / 16384.0f;
+        
+        // Fixup any quaternion values out of range
+        for (int i = 0; i < 4; i++) if (q[i] >= 2) q[i] = -4 + q[i];
+
+        // below calculations are necessary for calculation of yaw/pitch/roll, 
+        // and tilt-compensated compass heading
+        
+        // calculate gravity vector
+        gravity[0] = 2 * (q[1]*q[3] - q[0]*q[2]);
+        gravity[1] = 2 * (q[0]*q[1] + q[2]*q[3]);
+        gravity[2] = q[0]*q[0] - q[1]*q[1] - q[2]*q[2] + q[3]*q[3];
+        
+        // calculate Euler angles
+        // This code is here for reference, and is commented out for performance reasons
+        //euler[0] = atan2(2*q[1]*q[2] - 2*q[0]*q[3], 2*q[0]*q[0] + 2*q[1]*q[1] - 1);
+        //euler[1] = -asin(2*q[1]*q[3] + 2*q[0]*q[2]);
+        //euler[2] = atan2(2*q[2]*q[3] - 2*q[0]*q[1], 2*q[0]*q[0] + 2*q[3]*q[3] - 1);
+
+        // calculate yaw/pitch/roll angles
+        ypr[0] = atan2(2*q[1]*q[2] - 2*q[0]*q[3], 2*q[0]*q[0] + 2*q[1]*q[1] - 1);
+        ypr[1] = atan(gravity[0] / sqrt(gravity[1]*gravity[1] + gravity[2]*gravity[2]));
+        ypr[2] = atan(gravity[1] / sqrt(gravity[0]*gravity[0] + gravity[2]*gravity[2]));
+
+        // Convert yaw/pitch/roll angles to degreess, and remove calibrated offset
+        
+        yaw_degrees = ypr[0] * (180.0/3.1415926); 
+        pitch_degrees = ypr[1] * (180.0/3.1415926); 
+        roll_degrees = ypr[2] * (180.0/3.1415926); 
+         
+        // Subtract offset, and handle potential 360 degree wrap-around
+        yaw_degrees -= yaw_offset_degrees;
+        if ( yaw_degrees < -180 ) yaw_degrees += 360;
+        if ( yaw_degrees > 180 ) yaw_degrees -= 360;
+
+        // calculate linear acceleration by 
+        // removing the gravity component from raw acceleration values
+        // Note that this code assumes the acceleration full scale range
+        // is +/- 2 degrees
+         
+        linear_acceleration_x = (float)(((float)accel_x) / (32768.0 / (float)accel_fsr_g)) - gravity[0];
+        linear_acceleration_y = (float)(((float)accel_y) / (32768.0 / (float)accel_fsr_g)) - gravity[1];
+        linear_acceleration_z = (float)(((float)accel_z) / (32768.0 / (float)accel_fsr_g)) - gravity[2]; 
+        
+        // Calculate world-frame acceleration
+        
+        q2[0] = 0;
+        q2[1] = linear_acceleration_x;
+        q2[2] = linear_acceleration_y;
+        q2[3] = linear_acceleration_z;
+        
+        // Rotate linear acceleration so that it's relative to the world reference frame
+        
+        // http://www.cprogramming.com/tutorial/3d/quaternions.html
+        // http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/transforms/index.htm
+        // http://content.gpwiki.org/index.php/OpenGL:Tutorials:Using_Quaternions_to_represent_rotation
+        // ^ or: http://webcache.googleusercontent.com/search?q=cache:xgJAp3bDNhQJ:content.gpwiki.org/index.php/OpenGL:Tutorials:Using_Quaternions_to_represent_rotation&hl=en&gl=us&strip=1
+    
+        // P_out = q * P_in * conj(q)
+        // - P_out is the output vector
+        // - q is the orientation quaternion
+        // - P_in is the input vector (a*aReal)
+        // - conj(q) is the conjugate of the orientation quaternion (q=[w,x,y,z], q*=[w,-x,-y,-z])
+
+        // calculate quaternion product
+        // Quaternion multiplication is defined by:
+        //     (Q1 * Q2).w = (w1w2 - x1x2 - y1y2 - z1z2)
+        //     (Q1 * Q2).x = (w1x2 + x1w2 + y1z2 - z1y2)
+        //     (Q1 * Q2).y = (w1y2 - x1z2 + y1w2 + z1x2)
+        //     (Q1 * Q2).z = (w1z2 + x1y2 - y1x2 + z1w2
+        
+        q_product[0] = q[0]*q2[0] - q[1]*q2[1] - q[2]*q2[2] - q[3]*q2[3];  // new w
+        q_product[1] = q[0]*q2[1] + q[1]*q2[0] + q[2]*q2[3] - q[3]*q2[2];  // new x
+        q_product[2] = q[0]*q2[2] - q[1]*q2[3] + q[2]*q2[0] + q[3]*q2[1];  // new y 
+        q_product[3] = q[0]*q2[3] + q[1]*q2[2] - q[2]*q2[1] + q[3]*q2[0];  // new z
+
+        float q_conjugate[4];
+        
+        q_conjugate[0] = q[0];            
+        q_conjugate[1] = -q[1];            
+        q_conjugate[2] = -q[2];            
+        q_conjugate[3] = -q[3];            
+
+        float q_final[4];
+        
+        q_final[0] = q_product[0]*q_conjugate[0] - q_product[1]*q_conjugate[1] - q_product[2]*q_conjugate[2] - q_product[3]*q_conjugate[3];  // new w
+        q_final[1] = q_product[0]*q_conjugate[1] + q_product[1]*q_conjugate[0] + q_product[2]*q_conjugate[3] - q_product[3]*q_conjugate[2];  // new x
+        q_final[2] = q_product[0]*q_conjugate[2] - q_product[1]*q_conjugate[3] + q_product[2]*q_conjugate[0] + q_product[3]*q_conjugate[1];  // new y 
+        q_final[3] = q_product[0]*q_conjugate[3] + q_product[1]*q_conjugate[2] - q_product[2]*q_conjugate[1] + q_product[3]*q_conjugate[0];  // new z
+
+        world_linear_acceleration_x = q_final[1];
+        world_linear_acceleration_y = q_final[2];
+        world_linear_acceleration_z = q_final[3];
+        
+        // Calculate tilt-compensated compass heading
+        
+        float inverted_pitch = -ypr[1];
+        float roll = ypr[2];
+        
+        float cos_roll = cos(roll);
+        float sin_roll = sin(roll);
+        float cos_pitch = cos(inverted_pitch);
+        float sin_pitch = sin(inverted_pitch);
+        
+        float MAG_X = mag_x * cos_pitch + mag_z * sin_pitch;
+        float MAG_Y = mag_x * sin_roll * sin_pitch + mag_y * cos_roll - mag_z * sin_roll * cos_pitch;
+        float tilt_compensated_heading_radians = atan2(MAG_Y,MAG_X);
+        float tilt_compensated_heading_degrees = tilt_compensated_heading_radians * (180.0 / 3.1415926);
+        
+        // Adjust compass for board orientation,
+        // and modify range from -180-180 to
+        // 0-360 degrees
+      
+        tilt_compensated_heading_degrees -= 90.0;
+        if ( tilt_compensated_heading_degrees < 0 ) {
+          tilt_compensated_heading_degrees += 360; 
+        }
+
+		this->yaw = yaw_degrees;
+		this->pitch = pitch_degrees;
+		this->roll = roll_degrees;
+		this->compass_heading = tilt_compensated_heading_degrees;
+        
+		this->world_linear_accel_x = world_linear_acceleration_x;
+		this->world_linear_accel_y = world_linear_acceleration_y;
+		this->world_linear_accel_z = world_linear_acceleration_z;
+		this->temp_c = temp_c;
+		
+		UpdateYawHistory(this->yaw);
+		UpdateWorldLinearAccelHistory( world_linear_acceleration_x, world_linear_acceleration_y, world_linear_acceleration_z);
+	}	
+}

--- a/RecycleRushBot/H/AHRSProtocol.h
+++ b/RecycleRushBot/H/AHRSProtocol.h
@@ -1,0 +1,515 @@
+/* ============================================
+navX MXP source code is placed under the MIT license
+Copyright (c) 2015 Kauai Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+===============================================
+*/
+
+#ifndef _AHRS_PROTOCOL_H_
+#define _AHRS_PROTOCOL_H_
+
+/*****************************************************************************/
+/* This protocol, introduced first with the navX MXP, expands upon the IMU   */
+/* protocol by adding the following new functionality:                       */
+/*         																	 */
+/* AHRS Update:  Includes Fused Heading and Altitude Info                    */
+/* Magnetometer Calibration:  Enables configuration of coefficients from PC  */
+/* Board Identity:  Enables retrieval of Board Identification Info           */
+/* Fusion Tuning:  Enables configuration of key thresholds/coefficients used */
+/*                 in data fusion algorithms from a remote client            */
+/*                                                                           */
+/* In addition, the navX enable stream command has been extended with a new  */
+/* Stream type, in order to enable AHRS Updates.                             */
+/*****************************************************************************/
+
+#include "IMUProtocol.h"
+#include "IMURegisters.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define BINARY_PACKET_INDICATOR_CHAR '#'
+
+/* AHRS Protocol encodes certain data in binary format, unlike the IMU  */
+/* protocol, which encodes all data in ASCII characters.  Thus, the     */
+/* packet start and message termination sequences may occur within the  */
+/* message content itself.  To support the binary format, the binary    */
+/* message has this format:                                             */
+/*                                                                      */
+/* [start][binary indicator][len][msgid]<MESSAGE>[checksum][terminator] */
+/*                                                                      */
+/* (The binary indicator and len are not present in the ASCII protocol) */
+/*                                                                      */
+/* The [len] does not include the length of the start and binary        */
+/* indicator characters, but does include all other message items,      */
+/* including the checksum and terminator sequence.                      */
+
+typedef enum
+{
+	UNSPECIFIED = 0,
+	MOTION_THRESHOLD = 1,			/* In G */
+	YAW_STABLE_THRESHOLD = 2,		/* In Degrees */
+	MAG_DISTURBANCE_THRESHOLD =3,	/* Ratio */
+	SEA_LEVEL_PRESSURE = 4,			/* Millibars */
+	MIN_TUNING_VAR_ID = MOTION_THRESHOLD,
+	MAX_TUNING_VAR_ID = SEA_LEVEL_PRESSURE,
+} AHRS_TUNING_VAR_ID;
+
+typedef enum
+{
+	TUNING_VARIABLE = 0,
+	MAG_CALIBRATION = 1,
+	BOARD_IDENTITY = 2
+} AHRS_DATA_TYPE;
+
+typedef enum
+{
+	DATA_GET = 0,
+	DATA_SET = 1,
+	DATA_SET_TO_DEFAULT = 2,
+} AHRS_DATA_ACTION;
+
+#define DATA_GETSET_SUCCESS	0
+#define DATA_GETSET_ERROR	1
+
+// AHRS Update Packet - e.g., !a[yaw][pitch][roll][heading][altitude][fusedheading][accelx/y/z][angular rot x/y/z][opstatus][fusionstatus][cr][lf]
+
+#define MSGID_AHRS_UPDATE 'a'
+#define AHRS_UPDATE_YAW_VALUE_INDEX 					4  /* Degrees.  Signed Hundredths */
+#define AHRS_UPDATE_PITCH_VALUE_INDEX 					6  /* Degrees.  Signed Hundredeths */
+#define AHRS_UPDATE_ROLL_VALUE_INDEX 					8  /* Degrees.  Signed Hundredths */
+#define AHRS_UPDATE_HEADING_VALUE_INDEX 				10 /* Degrees.  Unsigned Hundredths */
+#define AHRS_UPDATE_ALTITUDE_VALUE_INDEX 				12 /* Meters.   Signed 16:16 */
+#define AHRS_UPDATE_FUSED_HEADING_VALUE_INDEX 			16 /* Degrees.  Unsigned Hundredths */
+#define AHRS_UPDATE_LINEAR_ACCEL_X_VALUE_INDEX 			18 /* Inst. G.  Signed Thousandths */
+#define AHRS_UPDATE_LINEAR_ACCEL_Y_VALUE_INDEX 			20 /* Inst. G.  Signed Thousandths */
+#define AHRS_UPDATE_LINEAR_ACCEL_Z_VALUE_INDEX 			22 /* Inst. G.  Signed Thousandths */
+#define AHRS_UPDATE_CAL_MAG_X_VALUE_INDEX				24 /* Int16 (Device Units) */
+#define AHRS_UPDATE_CAL_MAG_Y_VALUE_INDEX				26 /* Int16 (Device Units) */
+#define AHRS_UPDATE_CAL_MAG_Z_VALUE_INDEX  				28 /* Int16 (Device Units) */
+#define AHRS_UPDATE_CAL_MAG_NORM_RATIO_VALUE_INDEX		30 /* Ratio.  Unsigned Hundredths */
+#define AHRS_UPDATE_CAL_MAG_SCALAR_VALUE_INDEX			32 /* Coefficient. Signed q16:16 */
+#define AHRS_UPDATE_MPU_TEMP_VAUE_INDEX					36 /* Centigrade.  Signed Hundredths */
+#define AHRS_UPDATE_RAW_MAG_X_VALUE_INDEX               38 /* INT16 (Device Units) */
+#define AHRS_UPDATE_RAW_MAG_Y_VALUE_INDEX               40 /* INT16 (Device Units) */
+#define AHRS_UPDATE_RAW_MAG_Z_VALUE_INDEX               42 /* INT16 (Device Units) */
+#define AHRS_UPDATE_QUAT_W_VALUE_INDEX					44 /* INT16 */
+#define AHRS_UPDATE_QUAT_X_VALUE_INDEX					46 /* INT16 */
+#define AHRS_UPDATE_QUAT_Y_VALUE_INDEX					48 /* INT16 */
+#define AHRS_UPDATE_QUAT_Z_VALUE_INDEX					50 /* INT16 */
+#define AHRS_UPDATE_BARO_PRESSURE_VALUE_INDEX			52 /* millibar.  Signed 16:16 */
+#define AHRS_UPDATE_BARO_TEMP_VAUE_INDEX				56 /* Centigrade.  Signed  Hundredths */
+#define AHRS_UPDATE_OPSTATUS_VALUE_INDEX 				58 /* NAVX_OP_STATUS_XXX */
+#define AHRS_UPDATE_SENSOR_STATUS_VALUE_INDEX 			59 /* NAVX_SENSOR_STATUS_XXX */
+#define AHRS_UPDATE_CAL_STATUS_VALUE_INDEX				60 /* NAVX_CAL_STATUS_XXX */
+#define AHRS_UPDATE_SELFTEST_STATUS_VALUE_INDEX			61 /* NAVX_SELFTEST_STATUS_XXX */
+#define AHRS_UPDATE_MESSAGE_CHECKSUM_INDEX 				62
+#define AHRS_UPDATE_MESSAGE_TERMINATOR_INDEX 			64
+#define AHRS_UPDATE_MESSAGE_LENGTH 						66
+
+// Data Get Request:  Tuning Variable, Mag Cal, Board Identity (Response message depends upon request type)
+#define MSGID_DATA_REQUEST 'D'
+#define DATA_REQUEST_DATATYPE_VALUE_INDEX 				4
+#define DATA_REQUEST_VARIABLEID_VALUE_INDEX 			5
+#define DATA_REQUEST_CHECKSUM_INDEX 					6
+#define DATA_REQUEST_TERMINATOR_INDEX 					8
+#define DATA_REQUEST_MESSAGE_LENGTH 					10
+
+/* Data Set Response Packet (in response to MagCal SET and Tuning SET commands. */
+#define MSGID_DATA_SET_RESPONSE 'v'
+#define DATA_SET_RESPONSE_DATATYPE_VALUE_INDEX			4
+#define DATA_SET_RESPONSE_VARID_VALUE_INDEX				5
+#define DATA_SET_RESPONSE_STATUS_VALUE_INDEX			6
+#define DATA_SET_RESPONSE_MESSAGE_CHECKSUM_INDEX		7
+#define DATA_SET_RESPONSE_MESSAGE_TERMINATOR_INDEX		9
+#define DATA_SET_RESPONSE_MESSAGE_LENGTH				11
+
+/* Magnetometer Calibration Packet
+** This message may be used to SET (store) a new calibration into the navX board, or may be used
+** to retrieve the current calibration data from the navX board. */
+#define MSGID_MAG_CAL_CMD 'M'
+#define MAG_CAL_DATA_ACTION_VALUE_INDEX 				4
+#define MAG_X_BIAS_VALUE_INDEX 							5 /* signed short */
+#define MAG_Y_BIAS_VALUE_INDEX 							7
+#define MAG_Z_BIAS_VALUE_INDEX 							9
+#define MAG_XFORM_1_1_VALUE_INDEX 						11 /* signed 16:16 */
+#define MAG_XFORM_1_2_VALUE_INDEX 						15
+#define MAG_XFORM_1_3_VALUE_INDEX 						19
+#define MAG_XFORM_2_1_VALUE_INDEX 						23
+#define MAG_XFORM_2_2_VALUE_INDEX 						27
+#define MAG_XFORM_2_3_VALUE_INDEX 						31
+#define MAG_XFORM_3_1_VALUE_INDEX 						35
+#define MAG_XFORM_3_2_VALUE_INDEX 						39
+#define MAG_XFORM_3_3_VALUE_INDEX 						43
+#define MAG_CAL_EARTH_MAG_FIELD_NORM_VALUE_INDEX 		47
+#define MAG_CAL_CMD_MESSAGE_CHECKSUM_INDEX 				51
+#define MAG_CAL_CMD_MESSAGE_TERMINATOR_INDEX 			53
+#define MAG_CAL_CMD_MESSAGE_LENGTH						55
+
+/* Tuning Variable Packet
+** This message may be used to SET (modify) a tuning variable into the navX board,
+** or to retrieve a current tuning variable from the navX board. */
+#define MSGID_FUSION_TUNING_CMD 'T'
+#define FUSION_TUNING_DATA_ACTION_VALUE_INDEX			4
+#define FUSION_TUNING_CMD_VAR_ID_VALUE_INDEX			5
+#define FUSION_TUNING_CMD_VAR_VALUE_INDEX				6
+#define FUSION_TUNING_CMD_MESSAGE_CHECKSUM_INDEX 		10
+#define FUSION_TUNING_CMD_MESSAGE_TERMINATOR_INDEX 		12
+#define FUSION_TUNING_CMD_MESSAGE_LENGTH 				14
+
+// Board Identity Response Packet
+// Sent in response to a Data Get (Board ID) message
+#define MSGID_BOARD_IDENTITY_RESPONSE 'i'
+#define BOARD_IDENTITY_BOARDTYPE_VALUE_INDEX			4
+#define BOARD_IDENTITY_HWREV_VALUE_INDEX 				5
+#define BOARD_IDENTITY_FW_VER_MAJOR      				6
+#define BOARD_IDENTITY_FW_VER_MINOR      				7
+#define BOARD_IDENTITY_FW_VER_REVISION_VALUE_INDEX		8
+#define BOARD_IDENTITY_UNIQUE_ID_0       				10
+#define BOARD_IDENTITY_UNIQUE_ID_1       				11
+#define BOARD_IDENTITY_UNIQUE_ID_2       				12
+#define BOARD_IDENTITY_UNIQUE_ID_3       				13
+#define BOARD_IDENTITY_UNIQUE_ID_4       				14
+#define BOARD_IDENTITY_UNIQUE_ID_5       				15
+#define BOARD_IDENTITY_UNIQUE_ID_6       				16
+#define BOARD_IDENTITY_UNIQUE_ID_7       				17
+#define BOARD_IDENTITY_UNIQUE_ID_8       				18
+#define BOARD_IDENTITY_UNIQUE_ID_9       				19
+#define BOARD_IDENTITY_UNIQUE_ID_10      				20
+#define BOARD_IDENTITY_UNIQUE_ID_11      				21
+#define BOARD_IDENTITY_RESPONSE_CHECKSUM_INDEX 			22
+#define BOARD_IDENTITY_RESPONSE_TERMINATOR_INDEX 		24
+#define BOARD_IDENTITY_RESPONSE_MESSAGE_LENGTH 			26
+
+#define AHRS_PROTOCOL_MAX_MESSAGE_LENGTH AHRS_UPDATE_MESSAGE_LENGTH
+
+class AHRSProtocol : public IMUProtocol
+{
+public:
+
+static int encodeTuningVariableCmd( char *protocol_buffer, AHRS_DATA_ACTION getset, AHRS_TUNING_VAR_ID id, float val )
+{
+	  // Header
+	  protocol_buffer[0] = PACKET_START_CHAR;
+	  protocol_buffer[1] = BINARY_PACKET_INDICATOR_CHAR;
+	  protocol_buffer[2] = FUSION_TUNING_CMD_MESSAGE_LENGTH - 2;
+	  protocol_buffer[3] = MSGID_FUSION_TUNING_CMD;
+	  // Data
+	  protocol_buffer[FUSION_TUNING_DATA_ACTION_VALUE_INDEX] = getset;
+	  protocol_buffer[FUSION_TUNING_CMD_VAR_ID_VALUE_INDEX] = id;
+	  IMURegisters::encodeProtocol1616Float(val,&protocol_buffer[FUSION_TUNING_CMD_VAR_VALUE_INDEX]);
+	  // Footer
+	  encodeTermination( protocol_buffer, FUSION_TUNING_CMD_MESSAGE_LENGTH, FUSION_TUNING_CMD_MESSAGE_LENGTH - 4 );
+	  return FUSION_TUNING_CMD_MESSAGE_LENGTH;
+}
+
+static int decodeTuningVariableCmd( char *buffer, int length, AHRS_DATA_ACTION& getset, AHRS_TUNING_VAR_ID& id, float& val )
+{
+	  if ( length < FUSION_TUNING_CMD_MESSAGE_LENGTH ) return 0;
+	  if ( ( buffer[0] == PACKET_START_CHAR ) &&
+		   ( buffer[1] == BINARY_PACKET_INDICATOR_CHAR ) &&
+		   ( buffer[2] == FUSION_TUNING_CMD_MESSAGE_LENGTH - 2) &&
+		   ( buffer[3] == MSGID_FUSION_TUNING_CMD ) )
+	  {
+	    if ( !verifyChecksum( buffer, FUSION_TUNING_CMD_MESSAGE_CHECKSUM_INDEX ) ) return 0;
+
+		// Data
+		getset = (AHRS_DATA_ACTION)buffer[FUSION_TUNING_DATA_ACTION_VALUE_INDEX];
+		id = (AHRS_TUNING_VAR_ID)buffer[FUSION_TUNING_CMD_VAR_ID_VALUE_INDEX];
+		val = IMURegisters::decodeProtocol1616Float(&buffer[FUSION_TUNING_CMD_VAR_VALUE_INDEX]);
+	    return FUSION_TUNING_CMD_MESSAGE_LENGTH;
+	  }
+	  return 0;
+}
+
+static int encodeAHRSUpdate( char *protocol_buffer,
+								float yaw, float pitch, float roll,
+								float compass_heading, float altitude, float fused_heading,
+								float linear_accel_x, float linear_accel_y, float linear_accel_z,
+								float mpu_temp_c,
+								int16_t raw_mag_x, int16_t raw_mag_y, int16_t raw_mag_z,
+								int16_t cal_mag_x, int16_t cal_mag_y, int16_t cal_mag_z,
+								float mag_norm_ratio, float mag_norm_scalar,
+								int16_t quat_w, int16_t quat_x, int16_t quat_y, int16_t quat_z,
+								float baro_pressure, float baro_temp_c,
+								uint8_t op_status, uint8_t sensor_status,
+								uint8_t cal_status, uint8_t selftest_status )
+{
+	  // Header
+	  protocol_buffer[0] = PACKET_START_CHAR;
+	  protocol_buffer[1] = BINARY_PACKET_INDICATOR_CHAR;
+	  protocol_buffer[2] = AHRS_UPDATE_MESSAGE_LENGTH - 2;
+	  protocol_buffer[3] = MSGID_AHRS_UPDATE;
+	  // data
+	  IMURegisters::encodeProtocolSignedHundredthsFloat(yaw, &protocol_buffer[AHRS_UPDATE_YAW_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolSignedHundredthsFloat(pitch, &protocol_buffer[AHRS_UPDATE_PITCH_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolSignedHundredthsFloat(roll, &protocol_buffer[AHRS_UPDATE_ROLL_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolUnsignedHundredthsFloat(compass_heading, &protocol_buffer[AHRS_UPDATE_HEADING_VALUE_INDEX]);
+	  IMURegisters::encodeProtocol1616Float(altitude,&protocol_buffer[AHRS_UPDATE_ALTITUDE_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolUnsignedHundredthsFloat(fused_heading, &protocol_buffer[AHRS_UPDATE_FUSED_HEADING_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolSignedThousandthsFloat(linear_accel_x,&protocol_buffer[AHRS_UPDATE_LINEAR_ACCEL_X_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolSignedThousandthsFloat(linear_accel_y,&protocol_buffer[AHRS_UPDATE_LINEAR_ACCEL_Y_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolSignedThousandthsFloat(linear_accel_z,&protocol_buffer[AHRS_UPDATE_LINEAR_ACCEL_Z_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolInt16(cal_mag_x, &protocol_buffer[AHRS_UPDATE_CAL_MAG_X_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolInt16(cal_mag_y, &protocol_buffer[AHRS_UPDATE_CAL_MAG_Y_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolInt16(cal_mag_z, &protocol_buffer[AHRS_UPDATE_CAL_MAG_Z_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolUnsignedHundredthsFloat(mag_norm_ratio, &protocol_buffer[AHRS_UPDATE_CAL_MAG_NORM_RATIO_VALUE_INDEX]);
+	  IMURegisters::encodeProtocol1616Float(mag_norm_scalar, &protocol_buffer[AHRS_UPDATE_CAL_MAG_SCALAR_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolSignedHundredthsFloat(mpu_temp_c, &protocol_buffer[AHRS_UPDATE_MPU_TEMP_VAUE_INDEX]);
+	  IMURegisters::encodeProtocolInt16(raw_mag_x, &protocol_buffer[AHRS_UPDATE_RAW_MAG_X_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolInt16(raw_mag_y, &protocol_buffer[AHRS_UPDATE_RAW_MAG_Y_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolInt16(raw_mag_z, &protocol_buffer[AHRS_UPDATE_RAW_MAG_Z_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolInt16(quat_w, &protocol_buffer[AHRS_UPDATE_QUAT_W_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolInt16(quat_x, &protocol_buffer[AHRS_UPDATE_QUAT_X_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolInt16(quat_y, &protocol_buffer[AHRS_UPDATE_QUAT_Y_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolInt16(quat_z, &protocol_buffer[AHRS_UPDATE_QUAT_Z_VALUE_INDEX]);
+	  IMURegisters::encodeProtocol1616Float(baro_pressure, &protocol_buffer[AHRS_UPDATE_BARO_PRESSURE_VALUE_INDEX]);
+	  IMURegisters::encodeProtocolSignedHundredthsFloat(baro_temp_c, &protocol_buffer[AHRS_UPDATE_BARO_TEMP_VAUE_INDEX]);
+
+	  protocol_buffer[AHRS_UPDATE_OPSTATUS_VALUE_INDEX] = op_status;
+	  protocol_buffer[AHRS_UPDATE_SENSOR_STATUS_VALUE_INDEX] = sensor_status;
+	  protocol_buffer[AHRS_UPDATE_CAL_STATUS_VALUE_INDEX] = cal_status;
+	  protocol_buffer[AHRS_UPDATE_SELFTEST_STATUS_VALUE_INDEX] = selftest_status;
+	  // Footer
+	  encodeTermination( protocol_buffer, AHRS_UPDATE_MESSAGE_LENGTH, AHRS_UPDATE_MESSAGE_LENGTH - 4 );
+	  return AHRS_UPDATE_MESSAGE_LENGTH;
+}
+
+static int decodeAHRSUpdate( char *buffer, int length, float& yaw, float& pitch, float& roll, float& compass_heading,
+		float& altitude, float& fused_heading, float& linear_accel_x, float& linear_accel_y, float& linear_accel_z,
+		float& mpu_temp_c,
+		int16_t& raw_mag_x, int16_t& raw_mag_y, int16_t& raw_mag_z,
+		int16_t& cal_mag_x, int16_t& cal_mag_y, int16_t& cal_mag_z,
+		float& mag_norm_ratio, float& mag_norm_scalar,
+		int16_t& quat_w, int16_t& quat_x, int16_t& quat_y, int16_t& quat_z,
+		float& baro_pressure, float& baro_temp_c,
+		uint8_t& op_status, uint8_t& sensor_status,
+		uint8_t& cal_status, uint8_t& selftest_status)
+{
+  if ( length < AHRS_UPDATE_MESSAGE_LENGTH ) return 0;
+  if ( ( buffer[0] == PACKET_START_CHAR ) &&
+	   ( buffer[1] == BINARY_PACKET_INDICATOR_CHAR ) &&
+	   ( buffer[2] == AHRS_UPDATE_MESSAGE_LENGTH - 2) &&
+	   ( buffer[3] == MSGID_AHRS_UPDATE ) ) {
+
+    if ( !verifyChecksum( buffer, AHRS_UPDATE_MESSAGE_CHECKSUM_INDEX ) ) return 0;
+
+    yaw = IMURegisters::decodeProtocolSignedHundredthsFloat(&buffer[AHRS_UPDATE_YAW_VALUE_INDEX]);
+    pitch = IMURegisters::decodeProtocolSignedHundredthsFloat(&buffer[AHRS_UPDATE_PITCH_VALUE_INDEX]);
+    roll = IMURegisters::decodeProtocolSignedHundredthsFloat(&buffer[AHRS_UPDATE_ROLL_VALUE_INDEX]);
+    compass_heading = IMURegisters::decodeProtocolUnsignedHundredthsFloat(&buffer[AHRS_UPDATE_HEADING_VALUE_INDEX]);
+    altitude = IMURegisters::decodeProtocol1616Float(&buffer[AHRS_UPDATE_ALTITUDE_VALUE_INDEX]);
+    fused_heading = IMURegisters::decodeProtocolUnsignedHundredthsFloat(&buffer[AHRS_UPDATE_FUSED_HEADING_VALUE_INDEX]);
+    linear_accel_x = IMURegisters::decodeProtocolSignedThousandthsFloat(&buffer[AHRS_UPDATE_LINEAR_ACCEL_X_VALUE_INDEX]);
+    linear_accel_y = IMURegisters::decodeProtocolSignedThousandthsFloat(&buffer[AHRS_UPDATE_LINEAR_ACCEL_Y_VALUE_INDEX]);
+    linear_accel_z = IMURegisters::decodeProtocolSignedThousandthsFloat(&buffer[AHRS_UPDATE_LINEAR_ACCEL_Z_VALUE_INDEX]);
+    cal_mag_x = IMURegisters::decodeProtocolInt16(&buffer[AHRS_UPDATE_CAL_MAG_X_VALUE_INDEX]);
+    cal_mag_y = IMURegisters::decodeProtocolInt16(&buffer[AHRS_UPDATE_CAL_MAG_Y_VALUE_INDEX]);
+    cal_mag_z = IMURegisters::decodeProtocolInt16(&buffer[AHRS_UPDATE_CAL_MAG_Z_VALUE_INDEX]);
+    mag_norm_ratio = IMURegisters::decodeProtocolUnsignedHundredthsFloat(&buffer[AHRS_UPDATE_CAL_MAG_NORM_RATIO_VALUE_INDEX]);
+    mag_norm_scalar = IMURegisters::decodeProtocol1616Float(&buffer[AHRS_UPDATE_CAL_MAG_SCALAR_VALUE_INDEX]);
+	mpu_temp_c = IMURegisters::decodeProtocolSignedHundredthsFloat(&buffer[AHRS_UPDATE_MPU_TEMP_VAUE_INDEX]);
+	raw_mag_x = IMURegisters::decodeProtocolInt16(&buffer[AHRS_UPDATE_RAW_MAG_X_VALUE_INDEX]);
+	raw_mag_y = IMURegisters::decodeProtocolInt16(&buffer[AHRS_UPDATE_RAW_MAG_Y_VALUE_INDEX]);
+	raw_mag_z = IMURegisters::decodeProtocolInt16(&buffer[AHRS_UPDATE_RAW_MAG_Z_VALUE_INDEX]);
+	quat_w = IMURegisters::decodeProtocolInt16(&buffer[AHRS_UPDATE_QUAT_W_VALUE_INDEX]);
+	quat_x = IMURegisters::decodeProtocolInt16(&buffer[AHRS_UPDATE_QUAT_X_VALUE_INDEX]);
+	quat_y = IMURegisters::decodeProtocolInt16(&buffer[AHRS_UPDATE_QUAT_Y_VALUE_INDEX]);
+	quat_z = IMURegisters::decodeProtocolInt16(&buffer[AHRS_UPDATE_QUAT_Z_VALUE_INDEX]);
+	baro_pressure = IMURegisters::decodeProtocol1616Float(&buffer[AHRS_UPDATE_BARO_PRESSURE_VALUE_INDEX]);
+	baro_temp_c = IMURegisters::decodeProtocolSignedHundredthsFloat(&buffer[AHRS_UPDATE_BARO_TEMP_VAUE_INDEX]);
+    op_status = buffer[AHRS_UPDATE_OPSTATUS_VALUE_INDEX];
+    sensor_status = buffer[AHRS_UPDATE_SENSOR_STATUS_VALUE_INDEX];
+	cal_status = buffer[AHRS_UPDATE_CAL_STATUS_VALUE_INDEX];
+	selftest_status = buffer[AHRS_UPDATE_SELFTEST_STATUS_VALUE_INDEX];
+
+    return AHRS_UPDATE_MESSAGE_LENGTH;
+  }
+  return 0;
+}
+
+static int encodeMagCalCommand( char *protocol_buffer, AHRS_DATA_ACTION action, int16_t *bias, float *matrix, float earth_mag_field_norm )
+{
+  // Header
+  protocol_buffer[0] = PACKET_START_CHAR;
+  protocol_buffer[1] = BINARY_PACKET_INDICATOR_CHAR;
+  protocol_buffer[2] = MAG_CAL_CMD_MESSAGE_LENGTH - 2;
+  protocol_buffer[3] = MSGID_MAG_CAL_CMD;
+
+  // Data
+  protocol_buffer[MAG_CAL_DATA_ACTION_VALUE_INDEX] = action;
+  for ( int i = 0; i < 3; i++ ) {
+	  IMURegisters::encodeProtocolInt16(	bias[i],
+			  	  	  	  	  	  	  	  	&protocol_buffer[MAG_X_BIAS_VALUE_INDEX + (i * sizeof(int16_t))]);
+  }
+  for ( int i = 0; i < 9; i++ ) {
+	  IMURegisters::encodeProtocol1616Float( matrix[i], &protocol_buffer[MAG_XFORM_1_1_VALUE_INDEX + (i * sizeof(s_1616_float))]);
+  }
+  IMURegisters::encodeProtocol1616Float( earth_mag_field_norm, &protocol_buffer[MAG_CAL_EARTH_MAG_FIELD_NORM_VALUE_INDEX]);
+  // Footer
+  encodeTermination( protocol_buffer, MAG_CAL_CMD_MESSAGE_LENGTH, MAG_CAL_CMD_MESSAGE_LENGTH - 4 );
+  return MAG_CAL_CMD_MESSAGE_LENGTH;
+}
+
+static int decodeMagCalCommand( char *buffer, int length,
+					AHRS_DATA_ACTION& action,
+					int16_t *bias,
+					float *matrix,
+					float& earth_mag_field_norm)
+{
+  if ( length < MAG_CAL_CMD_MESSAGE_LENGTH ) return 0;
+  if ( ( buffer[0] == PACKET_START_CHAR ) &&
+	   ( buffer[1] == BINARY_PACKET_INDICATOR_CHAR ) &&
+	   ( buffer[2] == MAG_CAL_CMD_MESSAGE_LENGTH - 2) &&
+	   ( buffer[3] == MSGID_MAG_CAL_CMD ) ) {
+
+    if ( !verifyChecksum( buffer, MAG_CAL_CMD_MESSAGE_CHECKSUM_INDEX ) ) return 0;
+
+    action = (AHRS_DATA_ACTION)buffer[MAG_CAL_DATA_ACTION_VALUE_INDEX];
+    for ( int i = 0; i < 3; i++ ) {
+    	bias[i] = IMURegisters::decodeProtocolInt16(&buffer[MAG_X_BIAS_VALUE_INDEX + (i * sizeof(int16_t))]);
+    }
+    for ( int i = 0; i < 9; i++ ) {
+    	matrix[i] = IMURegisters::decodeProtocol1616Float(&buffer[MAG_XFORM_1_1_VALUE_INDEX + (i * sizeof(s_1616_float))]);
+    }
+    earth_mag_field_norm = IMURegisters::decodeProtocol1616Float(&buffer[MAG_CAL_EARTH_MAG_FIELD_NORM_VALUE_INDEX]);
+    return MAG_CAL_CMD_MESSAGE_LENGTH;
+  }
+  return 0;
+}
+
+static int encodeDataSetResponse( char *protocol_buffer, AHRS_DATA_TYPE type, AHRS_TUNING_VAR_ID subtype, uint8_t status )
+{
+  // Header
+  protocol_buffer[0] = PACKET_START_CHAR;
+  protocol_buffer[1] = BINARY_PACKET_INDICATOR_CHAR;
+  protocol_buffer[2] = DATA_SET_RESPONSE_MESSAGE_LENGTH - 2;
+  protocol_buffer[3] = MSGID_DATA_SET_RESPONSE;
+  // Data
+  protocol_buffer[DATA_SET_RESPONSE_DATATYPE_VALUE_INDEX] = type;
+  protocol_buffer[DATA_SET_RESPONSE_VARID_VALUE_INDEX] = subtype;
+  protocol_buffer[DATA_SET_RESPONSE_STATUS_VALUE_INDEX] = status;
+  // Footer
+  encodeTermination( protocol_buffer, DATA_SET_RESPONSE_MESSAGE_LENGTH, DATA_SET_RESPONSE_MESSAGE_LENGTH - 4 );
+  return DATA_SET_RESPONSE_MESSAGE_LENGTH;
+}
+
+static int decodeDataSetResponse( char *buffer, int length, AHRS_DATA_TYPE type, AHRS_TUNING_VAR_ID subtype, uint8_t& status )
+{
+	  if ( length < DATA_SET_RESPONSE_MESSAGE_LENGTH ) return 0;
+	  if ( ( buffer[0] == PACKET_START_CHAR ) &&
+		   ( buffer[1] == BINARY_PACKET_INDICATOR_CHAR ) &&
+		   ( buffer[2] == DATA_SET_RESPONSE_MESSAGE_LENGTH - 2) &&
+		   ( buffer[3] == MSGID_DATA_SET_RESPONSE ) ) {
+
+	    if ( !verifyChecksum( buffer, DATA_SET_RESPONSE_MESSAGE_CHECKSUM_INDEX ) ) return 0;
+
+	    type = (AHRS_DATA_TYPE)buffer[DATA_SET_RESPONSE_DATATYPE_VALUE_INDEX];
+	    subtype = (AHRS_TUNING_VAR_ID)buffer[DATA_SET_RESPONSE_VARID_VALUE_INDEX];
+	    status = buffer[DATA_SET_RESPONSE_STATUS_VALUE_INDEX];
+	    return DATA_SET_RESPONSE_MESSAGE_LENGTH;
+	  }
+	  return 0;
+}
+
+static int encodeDataGetRequest( char *protocol_buffer, AHRS_DATA_TYPE type, AHRS_TUNING_VAR_ID subtype )
+{
+  // Header
+  protocol_buffer[0] = PACKET_START_CHAR;
+  protocol_buffer[1] = BINARY_PACKET_INDICATOR_CHAR;
+  protocol_buffer[2] = DATA_REQUEST_MESSAGE_LENGTH - 2;
+  protocol_buffer[3] = MSGID_DATA_REQUEST;
+  // Data
+  protocol_buffer[DATA_REQUEST_DATATYPE_VALUE_INDEX] = type;
+  protocol_buffer[DATA_REQUEST_VARIABLEID_VALUE_INDEX] = subtype;
+  // Footer
+  encodeTermination( protocol_buffer, DATA_REQUEST_MESSAGE_LENGTH, DATA_REQUEST_MESSAGE_LENGTH - 4 );
+  return DATA_REQUEST_MESSAGE_LENGTH;
+}
+
+static int decodeDataGetRequest( char *buffer, int length, AHRS_DATA_TYPE& type, AHRS_TUNING_VAR_ID& subtype )
+{
+	if ( length < DATA_REQUEST_MESSAGE_LENGTH ) return 0;
+	if ( ( buffer[0] == PACKET_START_CHAR ) &&
+	     ( buffer[1] == BINARY_PACKET_INDICATOR_CHAR ) &&
+	     ( buffer[2] == DATA_REQUEST_MESSAGE_LENGTH - 2) &&
+	     ( buffer[3] == MSGID_DATA_REQUEST ) ) {
+
+		if ( !verifyChecksum( buffer, DATA_REQUEST_CHECKSUM_INDEX ) ) return 0;
+
+		type = (AHRS_DATA_TYPE)buffer[DATA_REQUEST_DATATYPE_VALUE_INDEX];
+		subtype = (AHRS_TUNING_VAR_ID)buffer[DATA_REQUEST_VARIABLEID_VALUE_INDEX];
+
+		return DATA_REQUEST_MESSAGE_LENGTH;
+	}
+	return 0;
+}
+
+static int encodeBoardIdentityResponse( char *protocol_buffer, uint8_t type, uint8_t fw_rev,
+										uint8_t fw_ver_major, uint8_t fw_ver_minor, uint16_t fw_revision,
+										uint8_t *unique_id)
+{
+  // Header
+  protocol_buffer[0] = PACKET_START_CHAR;
+  protocol_buffer[1] = BINARY_PACKET_INDICATOR_CHAR;
+  protocol_buffer[2] = BOARD_IDENTITY_RESPONSE_MESSAGE_LENGTH - 2;
+  protocol_buffer[3] = MSGID_BOARD_IDENTITY_RESPONSE;
+  // Data
+  protocol_buffer[BOARD_IDENTITY_BOARDTYPE_VALUE_INDEX] = type;
+  protocol_buffer[BOARD_IDENTITY_HWREV_VALUE_INDEX] = fw_rev;
+  protocol_buffer[BOARD_IDENTITY_FW_VER_MAJOR] = fw_ver_major;
+  protocol_buffer[BOARD_IDENTITY_FW_VER_MINOR] = fw_ver_minor;
+  IMURegisters::encodeProtocolUint16(fw_revision,&protocol_buffer[BOARD_IDENTITY_FW_VER_REVISION_VALUE_INDEX]);
+  for ( int i = 0; i < 12; i++ ) {
+	  protocol_buffer[BOARD_IDENTITY_UNIQUE_ID_0 + i] = unique_id[i];
+  }
+  // Footer
+  encodeTermination( protocol_buffer, BOARD_IDENTITY_RESPONSE_MESSAGE_LENGTH, BOARD_IDENTITY_RESPONSE_MESSAGE_LENGTH - 4 );
+  return BOARD_IDENTITY_RESPONSE_MESSAGE_LENGTH;
+}
+
+static int decodeBoardIdentityResponse( char *buffer, int length,
+										uint8_t& type, uint8_t& hw_rev,
+										uint8_t& fw_ver_major, uint8_t& fw_ver_minor, uint16_t& fw_revision,
+										uint8_t *unique_id)
+{
+	if ( length < BOARD_IDENTITY_RESPONSE_MESSAGE_LENGTH ) return 0;
+	if ( ( buffer[0] == PACKET_START_CHAR ) &&
+		 ( buffer[1] == BINARY_PACKET_INDICATOR_CHAR ) &&
+		 ( buffer[2] == BOARD_IDENTITY_RESPONSE_MESSAGE_LENGTH - 2) &&
+		 ( buffer[3] == MSGID_BOARD_IDENTITY_RESPONSE ) ) {
+		if ( !verifyChecksum( buffer, BOARD_IDENTITY_RESPONSE_CHECKSUM_INDEX ) ) return 0;
+
+		type = buffer[BOARD_IDENTITY_BOARDTYPE_VALUE_INDEX];
+		hw_rev = buffer[BOARD_IDENTITY_HWREV_VALUE_INDEX];
+		fw_ver_major = buffer[BOARD_IDENTITY_FW_VER_MAJOR];
+		fw_ver_minor = buffer[BOARD_IDENTITY_FW_VER_MINOR];
+		fw_revision = IMURegisters::decodeProtocolUint16(&buffer[BOARD_IDENTITY_FW_VER_REVISION_VALUE_INDEX]);
+		for ( int i = 0; i < 12; i++ ) {
+			unique_id[i] = buffer[BOARD_IDENTITY_UNIQUE_ID_0 + i];
+		}
+		return BOARD_IDENTITY_RESPONSE_MESSAGE_LENGTH;
+	}
+	return 0;
+}
+
+};
+
+#endif // _IMU_PROTOCOL_H_

--- a/RecycleRushBot/H/Elevator.h
+++ b/RecycleRushBot/H/Elevator.h
@@ -22,53 +22,53 @@ class Elevator
 		Elevator(uint elevMotorCh, uint elevPotCh, uint upperLimitSwCh, uint lowerLimitSwCh);
 		~Elevator();
 
-		void   SetInputPotRange(double minPotValue, double maxPotValue);  // DONE
-		bool   MoveElevator(double inputPotReading);                      // DONE
+		void   SetInputPotRange(double minPotValue, double maxPotValue);
+		bool   MoveElevator(double inputPotReading);
 		bool   MoveElevator(uint inputTarget, uint inputOffset);
-		float  GetMotorSpeed() const;                                     // DONE
-		double GetCurrentPosition() const;                                // DONE
-		double GetPositionTarget() const;                                 // DONE
-		double GetPositionTargetInput() const;                            // DONE
-		bool   GetUpperLimitSwitch() const;                               // DONE
-		bool   GetLowerLimitSwitch() const;                               // DONE
+		float  GetMotorSpeed() const;
+		double GetCurrentPosition() const;
+		double GetPositionTarget() const;
+		double GetPositionTargetInput() const;
+		bool   GetUpperLimitSwitch() const;
+		bool   GetLowerLimitSwitch() const;
 
 	private:
-		const float   MOTOR_SPEED_UP            =  0.10;
-		const float   MOTOR_SPEED_DOWN          = -0.10;
+		const float   MOTOR_SPEED_UP            =  0.10;   // CONFIGURE
+		const float   MOTOR_SPEED_DOWN          = -0.10;   // CONFIGURE
 		const float   ALL_STOP                  =  0.0;
 
-		const double  DEFAULT_INPUT_UPPER_LIMIT =  5.0;
-		const double  DEFAULT_INPUT_LOWER_LIMIT =  0.0;
-		const double  ELEV_POS_UPPER_LIMIT      =  5.0;
-		const double  ELEV_POS_LOWER_LIMIT      =  0.0;
-		const double  TARGET_TOLERANCE          =  0.02;
+		const double  DEFAULT_INPUT_UPPER_LIMIT =  5.0;    // CONFIGURE
+		const double  DEFAULT_INPUT_LOWER_LIMIT =  0.0;    // CONFIGURE
+		const double  ELEV_POS_UPPER_LIMIT      = 50.0;    // CONFIGURE
+		const double  ELEV_POS_LOWER_LIMIT      = 10.0;    // CONFIGURE
+		const double  TARGET_TOLERANCE          =  1.0;    // CONFIGURE
 
-		const double  POSITION1_BASE_TARGET     =  0.0;
-		const double  POSITION2_BASE_TARGET     =  1.0;
-		const double  POSITION3_BASE_TARGET     =  2.0;
-		const double  POSITION4_BASE_TARGET     =  3.0;
-		const double  POSITION5_BASE_TARGET     =  4.0;
-		const double  POSITION6_BASE_TARGET     =  5.0;
+		const double  POSITION1_BASE_TARGET     = 10.0;    // CONFIGURE
+		const double  POSITION2_BASE_TARGET     = 16.0;    // CONFIGURE
+		const double  POSITION3_BASE_TARGET     = 22.0;    // CONFIGURE
+		const double  POSITION4_BASE_TARGET     = 28.0;    // CONFIGURE
+		const double  POSITION5_BASE_TARGET     = 34.0;    // CONFIGURE
+		const double  POSITION6_BASE_TARGET     = 40.0;    // CONFIGURE
 		const double  OFFSET_GROUND             =  0.0;
-		const double  OFFSET_BURM               =  1.0;
-		const double  OFFSET_DIVIDER            =  2.0;
+		const double  OFFSET_BURM               =  2.0;    // CONFIGURE
+		const double  OFFSET_DIVIDER            =  4.0;    // CONFIGURE
 
 		const bool    PID_CONTROLLER_ON         =  true;
 		const bool    PID_CONTROLLER_OFF        =  false;
 
-		const double  POT_FULL_RANGE            =  5.0;
-		const double  POT_OFFSET                =  0.0;
+		const double  POT_FULL_RANGE            = 75.0;    // CONFIGURE
+		const double  POT_OFFSET                =  0.0;    // CONFIGURE
 
 		const float kP=27.9237; //PID controller constants
 		const float kI=0;
 		const float kD=0; //these will need to be set to the right values
 
-		void   CalcTargetRatioConstant();                  // DONE
-		double CalcTargetPotValue(double inputPotValue);   // DONE
+		void   CalcTargetRatioConstant();
+		double CalcTargetPotValue(double inputPotValue);
 		double CalcBaseTarget(uint basePosition);
 		double CalcOffsetTarget(uint offsetPosition);
-		bool   GoToPotTargetNoPID(double potTarget);       // DONE
-		bool   GoToPotTargetPID(double potTarget);         // DONE
+		bool   GoToPotTargetNoPID(double potTarget);
+		bool   GoToPotTargetPID(double potTarget);
 
 		Talon               *pElevatorMotor;
 		AnalogPotentiometer *pElevatorPot;
@@ -82,7 +82,7 @@ class Elevator
 		double              targetConstant;
 		double              targetInput;
 		double              elevatorTarget;
-		bool                usePIDController = PID_CONTROLLER_OFF;
+		bool                usePIDController = PID_CONTROLLER_OFF;  // CONFIGURE
 };
 
 #endif

--- a/RecycleRushBot/H/IMU.h
+++ b/RecycleRushBot/H/IMU.h
@@ -1,0 +1,100 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) Kauai Labs. All Rights Reserved.							  */
+/*                                                                            */
+/* Created in support of Team 2465 (Kauaibots).  Go Thunderchicken!           */
+/*                                                                            */
+/* Based upon the Open Source WPI Library released by FIRST robotics.         */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in $(WIND_BASE)/WPILib.  */
+/*----------------------------------------------------------------------------*/
+
+#ifndef IMU_H_
+#define IMU_H_
+
+#include "SensorBase.h"
+#include "PIDSource.h"
+#include "LiveWindow/LiveWindowSendable.h"
+#include "SerialPort.h"
+#include "Task.h"
+/**
+ * Use the IMU to retrieve a Yaw/Pitch/Roll measurement.
+ * 
+ * This utilizes the Kauai Labs Nav6 IMU.
+ * 
+ * This IMU interfaces to the CRio processor via a Serial port.
+ */
+
+#define YAW_HISTORY_LENGTH 10
+
+class IMU : public SensorBase, public PIDSource, public LiveWindowSendable
+{
+protected:
+	SerialPort *pserial_port;
+	IMU( SerialPort *pport, uint8_t update_rate_hz, char stream_type );
+	void InternalInit( SerialPort *pport, uint8_t update_rate_hz, char stream_type );
+public:
+
+	IMU( SerialPort *pport, uint8_t update_rate_hz = 100 );
+	virtual ~IMU();
+	virtual float GetPitch();	// Pitch, in units of degrees (-180 to 180)
+	virtual float GetRoll();	// Roll, in units of degrees (-180 to 180)
+	virtual float GetYaw();		// Yaw, in units of degrees (-180 to 180)
+	virtual float GetCompassHeading(); // CompassHeading, in units of degrees (0 to 360)
+	
+	bool IsConnected();
+	void ZeroYaw();
+	
+	// PIDSource interface, returns yaw component in units of degrees (-180 to 180)
+	double PIDGet();
+	
+	void UpdateTable();
+	void StartLiveWindowMode();
+	void StopLiveWindowMode();
+	std::string GetSmartDashboardType();
+	void InitTable(ITable *subTable);
+	ITable * GetTable();
+
+	SerialPort *GetSerialPort() { return pserial_port; }
+	void SetYawPitchRoll(float yaw, float pitch, float roll, float compass_heading);
+	void SetStreamResponse( char stream_type, 
+							uint16_t gyro_fsr_dps, uint16_t accel_fsr_g, uint16_t update_rate_hz,
+							float yaw_offset_degrees, 
+							uint16_t q1_offset, uint16_t q2_offset, uint16_t q3_offset, uint16_t q4_offset,
+							uint16_t flags );
+	double GetYawOffset() { return yaw_offset; }
+	double GetByteCount();
+	double GetUpdateCount();
+	void Restart();
+	bool  IsCalibrating();
+
+	uint8_t update_rate_hz;	
+	char current_stream_type;
+	virtual int DecodePacketHandler( char *received_data, int bytes_remaining );
+	
+private:
+	void InitializeYawHistory();
+	double GetAverageFromYawHistory();
+	void InitIMU();
+	
+
+protected:
+
+	void UpdateYawHistory(float curr_yaw );
+	
+	Task *	m_task;
+	float 	yaw;
+	float 	pitch; 
+	float 	roll;
+	float   compass_heading;
+	float 	yaw_history[YAW_HISTORY_LENGTH];
+	int 	next_yaw_history_index;
+	double 	last_update_time;
+	double 	yaw_offset;
+	float   yaw_offset_degrees;
+	uint16_t accel_fsr_g;
+	uint16_t gyro_fsr_dps;
+	uint16_t flags;
+    
+	ITable *m_table;
+};
+#endif

--- a/RecycleRushBot/H/IMUAdvanced.h
+++ b/RecycleRushBot/H/IMUAdvanced.h
@@ -1,0 +1,72 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) Kauai Labs. All Rights Reserved.							  */
+/*                                                                            */
+/* Created in support of Team 2465 (Kauaibots).  Go Thunderchicken!           */
+/*                                                                            */
+/* Based upon the Open Source WPI Library released by FIRST robotics.         */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in $(WIND_BASE)/WPILib.  */
+/*----------------------------------------------------------------------------*/
+
+#ifndef IMUADVANCED_H_
+#define IMUADVANCED_H_
+
+#include "../H/IMU.h"
+/**
+ * Use the IMU to retrieve a Yaw/Pitch/Roll measurement.
+ * 
+ * This utilizes the Kauai Labs Nav6 IMU.
+ * 
+ * This IMU interfaces to the CRio processor via a Serial port.
+ * 
+ * This is the "advanced" version of the IMU class, which uses the
+ * nav6 "Raw" messages, adding these additional features:
+ * 
+ * - calculate world-frame linear acceleration (gravity-removed)
+ * - monitor the temperature of the Invensense sensor
+ * - detection of motion/no-motion
+ * 
+ * Note that these additional features come at the expense of some
+ * additional processing.
+ */
+
+#define WORLD_LINEAR_ACCEL_HISTORY_LENGTH 10
+
+class IMUAdvanced : public IMU
+{
+public:
+
+	IMUAdvanced( SerialPort *pport, uint8_t update_rate_hz = 100 );
+	virtual ~IMUAdvanced();
+	
+	virtual float GetWorldLinearAccelX();
+	virtual float GetWorldLinearAccelY();
+	virtual float GetWorldLinearAccelZ();
+	virtual bool  IsMoving();
+	virtual float GetTempC();
+		
+	void SetQuaternion( int16_t q1, int16_t q2, int16_t q3, int16_t q4,
+						int16_t accel_x, int16_t accel_y, int16_t accel_z,
+						int16_t mag_x, int16_t mag_y, int16_t mag_z,
+						float temp_c);
+
+protected:
+	
+	int DecodePacketHandler( char *received_data, int bytes_remaining );
+	
+private:
+	void InitIMU();
+	void InitWorldLinearAccelHistory();
+	void UpdateWorldLinearAccelHistory( float x, float y, float z );
+	float GetAverageFromWorldLinearAccelHistory();
+
+	float   world_linear_accel_x;
+	float   world_linear_accel_y;
+	float   world_linear_accel_z;
+	float   temp_c;
+	float 	world_linear_accel_history[WORLD_LINEAR_ACCEL_HISTORY_LENGTH];
+	int 	next_world_linear_accel_history_index;
+	float	world_linear_acceleration_recent_avg;
+
+};
+#endif

--- a/RecycleRushBot/H/IMUProtocol.h
+++ b/RecycleRushBot/H/IMUProtocol.h
@@ -1,0 +1,446 @@
+/* ============================================
+Nav6 source code is placed under the MIT license
+Copyright (c) 2013 Kauai Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+===============================================
+*/
+
+#ifndef _IMU_PROTOCOL_H_
+#define _IMU_PROTOCOL_H_
+
+#define PACKET_START_CHAR '!'
+#define PROTOCOL_FLOAT_LENGTH 7
+#define CHECKSUM_LENGTH 2
+#define TERMINATOR_LENGTH 2
+
+// Yaw/Pitch/Roll (YPR) Update Packet - e.g., !y[yaw][pitch][roll][checksum][cr][lf]
+
+#define MSGID_YPR_UPDATE 'y'
+#define YPR_UPDATE_MESSAGE_LENGTH 34 	
+						//       where yaw, pitch, roll are floats
+						//		 where checksum is 2 ascii-bytes of HEX checksum (all bytes before checksum)
+#define YPR_UPDATE_YAW_VALUE_INDEX 2
+#define YPR_UPDATE_PITCH_VALUE_INDEX 9
+#define YPR_UPDATE_ROLL_VALUE_INDEX 16
+#define YPR_UPDATE_COMPASS_VALUE_INDEX 23
+#define YPR_UPDATE_CHECKSUM_INDEX 30
+#define YPR_UPDATE_TERMINATOR_INDEX 32
+
+// Quaternion Update Packet - e.g., !r[q1][q2][q3][q4][accelx][accely][accelz][magx][magy][magz][checksum][cr][lf]
+
+#define MSGID_QUATERNION_UPDATE 'q'
+#define QUATERNION_UPDATE_MESSAGE_LENGTH  				53      
+#define QUATERNION_UPDATE_QUAT1_VALUE_INDEX  			 2
+#define QUATERNION_UPDATE_QUAT2_VALUE_INDEX  			 6
+#define QUATERNION_UPDATE_QUAT3_VALUE_INDEX 			10
+#define QUATERNION_UPDATE_QUAT4_VALUE_INDEX 			14
+#define QUATERNION_UPDATE_ACCEL_X_VALUE_INDEX  		18
+#define QUATERNION_UPDATE_ACCEL_Y_VALUE_INDEX  		22
+#define QUATERNION_UPDATE_ACCEL_Z_VALUE_INDEX  		26	
+#define QUATERNION_UPDATE_MAG_X_VALUE_INDEX			30
+#define QUATERNION_UPDATE_MAG_Y_VALUE_INDEX            34
+#define QUATERNION_UPDATE_MAG_Z_VALUE_INDEX            38
+#define QUATERNION_UPDATE_TEMP_VALUE_INDEX				42
+#define QUATERNION_UPDATE_CHECKSUM_INDEX               49
+#define QUATERNION_UPDATE_TERMINATOR_INDEX             51
+
+// Gyro/Raw Data Update packet - e.g., !g[gx][gy][gz][accelx][accely][accelz][magx][magy][magz][temp_c][cr][lf]
+
+#define MSGID_GYRO_UPDATE 'g'
+#define GYRO_UPDATE_MESSAGE_LENGTH              46
+#define GYRO_UPDATE_GYRO_X_VALUE_INDEX			 2
+#define GYRO_UPDATE_GYRO_Y_VALUE_INDEX			 6
+#define GYRO_UPDATE_GYRO_Z_VALUE_INDEX			10
+#define GYRO_UPDATE_ACCEL_X_VALUE_INDEX			14
+#define GYRO_UPDATE_ACCEL_Y_VALUE_INDEX			18
+#define GYRO_UPDATE_ACCEL_Z_VALUE_INDEX			22
+#define GYRO_UPDATE_MAG_X_VALUE_INDEX			26
+#define GYRO_UPDATE_MAG_Y_VALUE_INDEX           30
+#define GYRO_UPDATE_MAG_Z_VALUE_INDEX           34
+#define GYRO_UPDATE_TEMP_VALUE_INDEX			38
+#define GYRO_UPDATE_CHECKSUM_INDEX              42
+#define GYRO_UPDATE_TERMINATOR_INDEX            44
+
+// EnableStream Command Packet - e.g., !S[stream type][checksum][cr][lf]
+
+#define MSGID_STREAM_CMD 'S'
+#define STREAM_CMD_MESSAGE_LENGTH 9
+#define STREAM_CMD_STREAM_TYPE_YPR MSGID_YPR_UPDATE
+#define STREAM_CMD_STREAM_TYPE_QUATERNION MSGID_QUATERNION_UPDATE
+#define STREAM_CMD_STREAM_TYPE_RAW MSGID_RAW_UPDATE
+#define STREAM_CMD_STREAM_TYPE_INDEX 2
+#define STREAM_CMD_UPDATE_RATE_HZ_INDEX 3
+#define STREAM_CMD_CHECKSUM_INDEX 5
+#define STREAM_CMD_TERMINATOR_INDEX 7
+
+// EnableStream Response Packet - e.g., !s[stream type][gyro full scale range][accel full scale range][update rate hz][yaw_offset_degrees][q1/2/3/4 offsets][flags][checksum][cr][lf]
+#define MSG_ID_STREAM_RESPONSE 's'
+#define STREAM_RESPONSE_MESSAGE_LENGTH 46
+#define STREAM_RESPONSE_STREAM_TYPE_INDEX 2
+#define STREAM_RESPONSE_GYRO_FULL_SCALE_DPS_RANGE 3
+#define STREAM_RESPONSE_ACCEL_FULL_SCALE_G_RANGE 7
+#define STREAM_RESPONSE_UPDATE_RATE_HZ 11
+#define STREAM_RESPONSE_YAW_OFFSET_DEGREES 15
+#define STREAM_RESPONSE_QUAT1_OFFSET          22
+#define STREAM_RESPONSE_QUAT2_OFFSET          26
+#define STREAM_RESPONSE_QUAT3_OFFSET          30
+#define STREAM_RESPONSE_QUAT4_OFFSET          34
+#define STREAM_RESPONSE_FLAGS 		      38
+#define STREAM_RESPONSE_CHECKSUM_INDEX 	      42
+#define STREAM_RESPONSE_TERMINATOR_INDEX      44
+
+#define NAV6_FLAG_MASK_CALIBRATION_STATE		0x03
+#define NAV6_CALIBRATION_STATE_WAIT    			0x00
+#define NAV6_CALIBRATION_STATE_ACCUMULATE		0x01
+#define NAV6_CALIBRATION_STATE_COMPLETE			0x02
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define IMU_PROTOCOL_MAX_MESSAGE_LENGTH RAW_UPDATE_MESSAGE_LENGTH
+
+class IMUProtocol
+{
+
+public:
+
+static int encodeYPRUpdate( char *protocol_buffer, float yaw, float pitch, float roll, float compass_heading )
+{
+  // Header
+  protocol_buffer[0] = PACKET_START_CHAR;
+  protocol_buffer[1] = MSGID_YPR_UPDATE;
+  
+  // Data
+  encodeProtocolFloat( yaw,    &protocol_buffer[YPR_UPDATE_YAW_VALUE_INDEX] );
+  encodeProtocolFloat( pitch,  &protocol_buffer[YPR_UPDATE_PITCH_VALUE_INDEX] );
+  encodeProtocolFloat( roll,    &protocol_buffer[YPR_UPDATE_ROLL_VALUE_INDEX] );
+  encodeProtocolFloat( compass_heading, &protocol_buffer[YPR_UPDATE_COMPASS_VALUE_INDEX] );
+  
+  // Footer
+  encodeTermination( protocol_buffer, YPR_UPDATE_MESSAGE_LENGTH, YPR_UPDATE_MESSAGE_LENGTH - 4 );
+
+  return YPR_UPDATE_MESSAGE_LENGTH;
+}
+
+static int encodeQuaternionUpdate( char *protocol_buffer, 
+							uint16_t q1, uint16_t q2, uint16_t q3, uint16_t q4, 
+							uint16_t accel_x, uint16_t accel_y, uint16_t accel_z,
+							int16_t mag_x, int16_t mag_y, int16_t mag_z,
+							float temp_c )
+{
+  // Header
+  protocol_buffer[0] = PACKET_START_CHAR;
+  protocol_buffer[1] = MSGID_QUATERNION_UPDATE;
+  
+  // Data
+  encodeProtocolUint16( q1,    				&protocol_buffer[QUATERNION_UPDATE_QUAT1_VALUE_INDEX] );
+  encodeProtocolUint16( q2,    				&protocol_buffer[QUATERNION_UPDATE_QUAT2_VALUE_INDEX] );
+  encodeProtocolUint16( q3,    				&protocol_buffer[QUATERNION_UPDATE_QUAT3_VALUE_INDEX] );
+  encodeProtocolUint16( q4,    				&protocol_buffer[QUATERNION_UPDATE_QUAT4_VALUE_INDEX] );
+  encodeProtocolUint16( accel_x,			&protocol_buffer[QUATERNION_UPDATE_ACCEL_X_VALUE_INDEX] );
+  encodeProtocolUint16( accel_y,			&protocol_buffer[QUATERNION_UPDATE_ACCEL_Y_VALUE_INDEX] );
+  encodeProtocolUint16( accel_z,			&protocol_buffer[QUATERNION_UPDATE_ACCEL_Z_VALUE_INDEX] );
+  encodeProtocolUint16( (uint16_t)mag_x,	&protocol_buffer[QUATERNION_UPDATE_MAG_X_VALUE_INDEX] );
+  encodeProtocolUint16( (uint16_t)mag_y,	&protocol_buffer[QUATERNION_UPDATE_MAG_Y_VALUE_INDEX] );
+  encodeProtocolUint16( (uint16_t)mag_z,	&protocol_buffer[QUATERNION_UPDATE_MAG_Z_VALUE_INDEX] );
+  encodeProtocolFloat(  temp_c,				&protocol_buffer[QUATERNION_UPDATE_TEMP_VALUE_INDEX] );
+  
+  // Footer
+  encodeTermination( protocol_buffer, QUATERNION_UPDATE_MESSAGE_LENGTH, QUATERNION_UPDATE_MESSAGE_LENGTH - 4 );
+
+  return QUATERNION_UPDATE_MESSAGE_LENGTH;
+}
+
+static int encodeGyroUpdate( char *protocol_buffer, 
+							uint16_t gyro_x, uint16_t gyro_y, uint16_t gyro_z, 
+							uint16_t accel_x, uint16_t accel_y, uint16_t accel_z,
+							int16_t mag_x, int16_t mag_y, int16_t mag_z,
+							float temp_c )
+{
+  // Header
+  protocol_buffer[0] = PACKET_START_CHAR;
+  protocol_buffer[1] = MSGID_GYRO_UPDATE;
+  
+  // Data
+  encodeProtocolUint16( gyro_x, 			&protocol_buffer[GYRO_UPDATE_GYRO_X_VALUE_INDEX] );
+  encodeProtocolUint16( gyro_y, 			&protocol_buffer[GYRO_UPDATE_GYRO_Y_VALUE_INDEX] );
+  encodeProtocolUint16( gyro_z, 			&protocol_buffer[GYRO_UPDATE_GYRO_Z_VALUE_INDEX] );
+  encodeProtocolUint16( accel_x,			&protocol_buffer[GYRO_UPDATE_ACCEL_X_VALUE_INDEX] );
+  encodeProtocolUint16( accel_y,			&protocol_buffer[GYRO_UPDATE_ACCEL_Y_VALUE_INDEX] );
+  encodeProtocolUint16( accel_z,			&protocol_buffer[GYRO_UPDATE_ACCEL_Z_VALUE_INDEX] );
+  encodeProtocolUint16( (uint16_t)mag_x,	&protocol_buffer[GYRO_UPDATE_MAG_X_VALUE_INDEX] );
+  encodeProtocolUint16( (uint16_t)mag_y,	&protocol_buffer[GYRO_UPDATE_MAG_Y_VALUE_INDEX] );
+  encodeProtocolUint16( (uint16_t)mag_z,	&protocol_buffer[GYRO_UPDATE_MAG_Z_VALUE_INDEX] );
+  encodeProtocolFloat(  temp_c,				&protocol_buffer[GYRO_UPDATE_TEMP_VALUE_INDEX] );
+  
+  // Footer
+  encodeTermination( protocol_buffer, GYRO_UPDATE_MESSAGE_LENGTH, GYRO_UPDATE_MESSAGE_LENGTH - 4 );
+
+  return GYRO_UPDATE_MESSAGE_LENGTH;
+}
+
+static int encodeStreamCommand( char *protocol_buffer, char stream_type, unsigned char update_rate_hz)
+{
+  // Header
+  protocol_buffer[0] = PACKET_START_CHAR;
+  protocol_buffer[1] = MSGID_STREAM_CMD;
+  
+  // Data
+  protocol_buffer[STREAM_CMD_STREAM_TYPE_INDEX] = stream_type;
+  // convert update_rate_hz to two ascii bytes
+  sprintf(&protocol_buffer[STREAM_CMD_UPDATE_RATE_HZ_INDEX], "%02X", update_rate_hz);
+  
+  // Footer
+  encodeTermination( protocol_buffer, STREAM_CMD_MESSAGE_LENGTH, STREAM_CMD_MESSAGE_LENGTH - 4 );
+
+  return STREAM_CMD_MESSAGE_LENGTH;
+}
+
+static int encodeStreamResponse( char *protocol_buffer, char stream_type, 
+					uint16_t gyro_fsr_dps, uint16_t accel_fsr_g, uint16_t update_rate_hz, 
+					float yaw_offset_degrees, 
+					uint16_t q1_offset, uint16_t q2_offset, uint16_t q3_offset, uint16_t q4_offset,
+					uint16_t flags)
+{
+  // Header
+  protocol_buffer[0] = PACKET_START_CHAR;
+  protocol_buffer[1] = MSG_ID_STREAM_RESPONSE;
+  
+  // Data
+  protocol_buffer[STREAM_RESPONSE_STREAM_TYPE_INDEX] = stream_type;
+  encodeProtocolUint16( gyro_fsr_dps, &protocol_buffer[STREAM_RESPONSE_GYRO_FULL_SCALE_DPS_RANGE] );
+  encodeProtocolUint16( accel_fsr_g, &protocol_buffer[STREAM_RESPONSE_ACCEL_FULL_SCALE_G_RANGE] );
+  encodeProtocolUint16( update_rate_hz, &protocol_buffer[STREAM_RESPONSE_UPDATE_RATE_HZ] );
+  encodeProtocolFloat(  yaw_offset_degrees, &protocol_buffer[STREAM_RESPONSE_YAW_OFFSET_DEGREES] );
+  encodeProtocolUint16(  q1_offset, &protocol_buffer[STREAM_RESPONSE_QUAT1_OFFSET]);
+  encodeProtocolUint16(  q2_offset, &protocol_buffer[STREAM_RESPONSE_QUAT2_OFFSET]);
+  encodeProtocolUint16(  q3_offset, &protocol_buffer[STREAM_RESPONSE_QUAT3_OFFSET]);
+  encodeProtocolUint16(  q4_offset, &protocol_buffer[STREAM_RESPONSE_QUAT4_OFFSET]);
+  encodeProtocolUint16(  flags, &protocol_buffer[STREAM_RESPONSE_FLAGS] );
+ 
+  // Footer
+  encodeTermination( protocol_buffer, STREAM_RESPONSE_MESSAGE_LENGTH, STREAM_RESPONSE_MESSAGE_LENGTH - 4 );
+
+  return STREAM_RESPONSE_MESSAGE_LENGTH;
+}
+
+static int decodeStreamResponse( char *buffer, int length, 
+					char& stream_type, uint16_t& gyro_fsr_dps, uint16_t& accel_fsr_g, uint16_t& update_rate_hz,
+					float& yaw_offset_degrees, 
+					uint16_t& q1_offset, uint16_t& q2_offset, uint16_t& q3_offset, uint16_t& q4_offset,
+					uint16_t& flags )
+{
+  if ( length < STREAM_RESPONSE_MESSAGE_LENGTH ) return 0;
+  if ( ( buffer[0] == PACKET_START_CHAR ) && ( buffer[1] == MSG_ID_STREAM_RESPONSE ) )
+  {
+    if ( !verifyChecksum( buffer, STREAM_RESPONSE_CHECKSUM_INDEX ) ) return 0;
+
+	stream_type			= buffer[2];
+    gyro_fsr_dps   		= decodeProtocolUint16( &buffer[STREAM_RESPONSE_GYRO_FULL_SCALE_DPS_RANGE] );
+    accel_fsr_g   		= decodeProtocolUint16( &buffer[STREAM_RESPONSE_ACCEL_FULL_SCALE_G_RANGE] );
+    update_rate_hz 		= decodeProtocolUint16( &buffer[STREAM_RESPONSE_UPDATE_RATE_HZ] );
+    yaw_offset_degrees 		= decodeProtocolFloat( &buffer[STREAM_RESPONSE_YAW_OFFSET_DEGREES] );
+    q1_offset			= decodeProtocolUint16(  &buffer[STREAM_RESPONSE_QUAT1_OFFSET]);
+    q2_offset 			= decodeProtocolUint16(  &buffer[STREAM_RESPONSE_QUAT2_OFFSET]);
+    q3_offset 			= decodeProtocolUint16(  &buffer[STREAM_RESPONSE_QUAT3_OFFSET]);
+    q4_offset 			= decodeProtocolUint16(  &buffer[STREAM_RESPONSE_QUAT4_OFFSET]);
+    flags				= decodeProtocolUint16( &buffer[STREAM_RESPONSE_FLAGS] );
+    return STREAM_RESPONSE_MESSAGE_LENGTH;
+  }
+  return 0;
+}
+
+
+static int decodeStreamCommand( char *buffer, int length, char& stream_type, unsigned char& update_rate_hz )
+{
+  if ( length < STREAM_CMD_MESSAGE_LENGTH ) return 0;
+  if ( ( buffer[0] == '!' ) && ( buffer[1] == MSGID_STREAM_CMD ) )
+  {
+    if ( !verifyChecksum( buffer, STREAM_CMD_CHECKSUM_INDEX ) ) return 0;
+
+    stream_type = buffer[STREAM_CMD_STREAM_TYPE_INDEX];
+	update_rate_hz = decodeUint8( &buffer[STREAM_CMD_UPDATE_RATE_HZ_INDEX] );
+
+    return STREAM_CMD_MESSAGE_LENGTH;
+  }
+  return 0;
+}
+
+static int decodeYPRUpdate( char *buffer, int length, float& yaw, float& pitch, float& roll, float& compass_heading )
+{
+  if ( length < YPR_UPDATE_MESSAGE_LENGTH ) return 0;
+  if ( ( buffer[0] == '!' ) && ( buffer[1] == 'y' ) )
+  {
+    if ( !verifyChecksum( buffer, YPR_UPDATE_CHECKSUM_INDEX ) ) return 0;
+
+    yaw   = decodeProtocolFloat( &buffer[YPR_UPDATE_YAW_VALUE_INDEX] );
+    pitch = decodeProtocolFloat( &buffer[YPR_UPDATE_PITCH_VALUE_INDEX] );
+    roll  = decodeProtocolFloat( &buffer[YPR_UPDATE_ROLL_VALUE_INDEX] );
+	compass_heading = decodeProtocolFloat( &buffer[YPR_UPDATE_COMPASS_VALUE_INDEX] );
+	return YPR_UPDATE_MESSAGE_LENGTH;
+  }
+  return 0;
+}
+
+static int decodeQuaternionUpdate( char *buffer, int length, 
+									int16_t& q1, int16_t& q2, int16_t& q3, int16_t& q4,
+									int16_t& accel_x, int16_t& accel_y, int16_t& accel_z,
+									int16_t& mag_x, int16_t& mag_y, int16_t& mag_z,
+									float& temp_c )
+{
+  if ( length < QUATERNION_UPDATE_MESSAGE_LENGTH ) return 0;
+  if ( ( buffer[0] == PACKET_START_CHAR ) && ( buffer[1] == MSGID_QUATERNION_UPDATE ) )
+  {
+    if ( !verifyChecksum( buffer, QUATERNION_UPDATE_CHECKSUM_INDEX ) ) return 0;
+
+    q1   	= (int16_t)decodeProtocolUint16( &buffer[QUATERNION_UPDATE_QUAT1_VALUE_INDEX] );
+    q2   	= (int16_t)decodeProtocolUint16( &buffer[QUATERNION_UPDATE_QUAT2_VALUE_INDEX] );
+    q3   	= (int16_t)decodeProtocolUint16( &buffer[QUATERNION_UPDATE_QUAT3_VALUE_INDEX] );
+    q4   	= (int16_t)decodeProtocolUint16( &buffer[QUATERNION_UPDATE_QUAT4_VALUE_INDEX] );
+    accel_x	= (int16_t)decodeProtocolUint16( &buffer[QUATERNION_UPDATE_ACCEL_X_VALUE_INDEX] );
+    accel_y	= (int16_t)decodeProtocolUint16( &buffer[QUATERNION_UPDATE_ACCEL_Y_VALUE_INDEX] );
+    accel_z	= (int16_t)decodeProtocolUint16( &buffer[QUATERNION_UPDATE_ACCEL_Z_VALUE_INDEX] );
+    mag_x	= (int16_t)decodeProtocolUint16( &buffer[QUATERNION_UPDATE_MAG_X_VALUE_INDEX] );
+    mag_y	= (int16_t)decodeProtocolUint16( &buffer[QUATERNION_UPDATE_MAG_Y_VALUE_INDEX] );
+    mag_z	= (int16_t)decodeProtocolUint16( &buffer[QUATERNION_UPDATE_MAG_Z_VALUE_INDEX] );
+	temp_c  = decodeProtocolFloat(  &buffer[QUATERNION_UPDATE_TEMP_VALUE_INDEX] );
+	return QUATERNION_UPDATE_MESSAGE_LENGTH;
+  }
+  return 0;
+}
+
+static int decodeGyroUpdate( char *buffer, int length, 
+							uint16_t& gyro_x, uint16_t& gyro_y, uint16_t& gyro_z, 
+							uint16_t& accel_x, uint16_t& accel_y, uint16_t& accel_z,
+							int16_t& mag_x, int16_t& mag_y, int16_t& mag_z,
+							float& temp_c )
+{
+  if ( length < GYRO_UPDATE_MESSAGE_LENGTH ) return 0;
+  if ( ( buffer[0] == PACKET_START_CHAR ) && ( buffer[1] == MSGID_GYRO_UPDATE ) )
+  {
+    if ( !verifyChecksum( buffer, GYRO_UPDATE_CHECKSUM_INDEX ) ) return 0;
+
+    gyro_x	= decodeProtocolUint16( &buffer[GYRO_UPDATE_GYRO_X_VALUE_INDEX] );
+    gyro_y  = decodeProtocolUint16( &buffer[GYRO_UPDATE_GYRO_Y_VALUE_INDEX] );
+    gyro_z	= decodeProtocolUint16( &buffer[GYRO_UPDATE_GYRO_Z_VALUE_INDEX] );
+    accel_x	= decodeProtocolUint16( &buffer[GYRO_UPDATE_ACCEL_X_VALUE_INDEX] );
+    accel_y	= decodeProtocolUint16( &buffer[GYRO_UPDATE_ACCEL_Y_VALUE_INDEX] );
+    accel_z	= decodeProtocolUint16( &buffer[GYRO_UPDATE_ACCEL_Z_VALUE_INDEX] );
+    mag_x	= (int16_t)decodeProtocolUint16( &buffer[GYRO_UPDATE_MAG_X_VALUE_INDEX] );
+    mag_y	= (int16_t)decodeProtocolUint16( &buffer[GYRO_UPDATE_MAG_Y_VALUE_INDEX] );
+    mag_z	= (int16_t)decodeProtocolUint16( &buffer[GYRO_UPDATE_MAG_Z_VALUE_INDEX] );
+	temp_c  = decodeProtocolFloat(  &buffer[GYRO_UPDATE_TEMP_VALUE_INDEX] );
+	return GYRO_UPDATE_MESSAGE_LENGTH;
+  }
+  return 0;
+}
+
+protected:
+
+static void encodeTermination( char *buffer, int total_length, int content_length )
+{
+  if ( ( total_length >= (CHECKSUM_LENGTH + TERMINATOR_LENGTH) ) && ( total_length >= content_length + (CHECKSUM_LENGTH + TERMINATOR_LENGTH) ) )
+  {
+    // Checksum 
+    unsigned char checksum = 0;
+    for ( int i = 0; i < content_length; i++ )
+    {
+      checksum += buffer[i];
+    }
+    // convert checksum to two ascii bytes
+    sprintf(&buffer[content_length], "%02X", checksum);
+    // Message Terminator
+    sprintf(&buffer[content_length + CHECKSUM_LENGTH], "%s","\r\n");
+  }
+}
+
+// Formats a float as follows
+//
+// e.g., -129.235
+//
+// "-129.24"
+//
+// e.g., 23.4
+//
+// "+023.40"
+
+static void encodeProtocolFloat( float f, char* buff )
+{
+  int temp1 = abs((int)((f - (int)f) * 100));
+  if ( f < 0 ) buff[0] = '-'; else buff[0] = ' ';
+  sprintf(&buff[1],"%03d.%02d", abs((int)f), temp1);
+}
+
+static void encodeProtocolUint16( uint16_t value, char* buff )
+{
+  sprintf(&buff[0],"%04X", value );
+}
+
+static uint16_t decodeProtocolUint16( char *uint16_string )
+{
+	uint16_t decoded_uint16 = 0;
+	unsigned int shift_left = 12;
+	for ( int i = 0; i < 4; i++ ) 
+	{
+		unsigned char digit = uint16_string[i] <= '9' ? uint16_string[i] - '0' : ((uint16_string[i] - 'A') + 10);
+		decoded_uint16 += (((uint16_t)digit) << shift_left);
+		shift_left -= 4;
+	}
+	return decoded_uint16;  
+}  
+
+
+static bool verifyChecksum( char *buffer, int content_length )
+{
+    // Calculate Checksum
+    unsigned char checksum = 0;
+    for ( int i = 0; i < content_length; i++ )
+    {
+      checksum += buffer[i];
+    }
+
+    // Decode Checksum
+    unsigned char decoded_checksum = decodeUint8( &buffer[content_length] );
+    
+    return ( checksum == decoded_checksum );
+}
+
+static unsigned char decodeUint8( char *checksum )
+{
+	unsigned char first_digit = checksum[0] <= '9' ? checksum[0] - '0' : ((checksum[0] - 'A') + 10);
+	unsigned char second_digit = checksum[1] <= '9' ? checksum[1] - '0' : ((checksum[1] - 'A') + 10);
+	unsigned char decoded_checksum = (first_digit * 16) + second_digit;
+	return decoded_checksum;  
+}  
+
+static float decodeProtocolFloat( char *buffer )
+{
+  char temp[PROTOCOL_FLOAT_LENGTH+1];
+  for ( int i = 0; i < PROTOCOL_FLOAT_LENGTH; i++ )
+  {
+    temp[i] = buffer[i];
+  }
+  temp[PROTOCOL_FLOAT_LENGTH] = 0;
+  return atof(temp);
+}
+
+};
+
+#endif // _IMU_PROTOCOL_H_

--- a/RecycleRushBot/H/IMURegisters.h
+++ b/RecycleRushBot/H/IMURegisters.h
@@ -1,0 +1,362 @@
+/* ============================================
+navX MXP source code is placed under the MIT license
+Copyright (c) 2015 Kauai Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+===============================================
+*/
+
+#ifndef IMU_REGISTERS_H_
+#define IMU_REGISTERS_H_
+
+#include "IMUProtocol.h"
+
+/*******************************************************************/
+/*******************************************************************/
+/*                      Register Definitions                       */
+/*******************************************************************/
+/* NOTE:  All multi-byte registers are in little-endian format.    */
+/*        All registers with 'signed' data are twos-complement.    */
+/*        Data Type Summary:                                       */
+/*        unsigned byte:           0   - 255    (8 bits)           */
+/*        unsigned short:          0   - 65535  (16 bits)          */
+/*        signed short:        -32768  - 32767  (16 bits)          */
+/*        signed hundredeths:  -327.68 - 327.67 (16 bits)		   */
+/*        unsigned hundredths:    0.0  - 655.35 (16 bits)          */
+/*        signed thousandths:  -32.768 - 32.767 (16 bits)          */
+/*        signed short ratio: -1/16384 - 1/16384 (16 bits)         */
+/*        16:16:           -32768.9999 - 32767.9999 (32 bits)      */
+/*        unsigned long:             0 - 4294967295 (32 bits)      */
+/*******************************************************************/
+
+typedef int16_t		s_short_hundred_float;
+typedef uint16_t	u_short_hundred_float;
+typedef int16_t     s_short_thousand_float;
+typedef int16_t     s_short_ratio_float;
+typedef int32_t     s_1616_float;
+
+/**********************************************/
+/* Device Identification Registers            */
+/**********************************************/
+
+#define NAVX_REG_WHOAMI 			0x00 /* IMU_MODEL_XXX */
+#define NAVX_REG_HW_REV				0x01
+#define NAVX_REG_FW_VER_MAJOR		0x02
+#define NAVX_REG_FW_VER_MINOR 		0x03
+
+/**********************************************/
+/* Status and Control Registers               */
+/**********************************************/
+
+/* Read-write */
+#define NAVX_REG_UPDATE_RATE_HZ		0x04 /* Range:  4 - 50 [unsigned byte] */
+/* Read-only */
+/* Accelerometer Full-Scale Range:  in units of G [unsigned byte] */
+#define NAVX_REG_ACCEL_FSR_G		0x05
+/* Gyro Full-Scale Range (Degrees/Sec):  Range:  250, 500, 1000 or 2000 [unsigned short] */
+#define NAVX_REG_GYRO_FSR_DPS_L		0x06 /* Lower 8-bits of Gyro Full-Scale Range */
+#define NAVX_REG_GYRO_FSR_DPS_H		0x07 /* Upper 8-bits of Gyro Full-Scale Range */
+#define NAVX_REG_OP_STATUS       	0x08 /* NAVX_OP_STATUS_XXX */
+#define NAVX_REG_CAL_STATUS       	0x09 /* NAVX_CAL_STATUS_XXX */
+#define NAVX_REG_SELFTEST_STATUS 	0x0A /* NAVX_SELFTEST_STATUS_XXX */
+
+/**********************************************/
+/* Processed Data Registers                   */
+/**********************************************/
+
+#define NAVX_REG_SENSOR_STATUS_L	0x10 /* NAVX_SENSOR_STATUS_XXX */
+#define NAVX_REG_SENSOR_STATUS_H	0x11
+/* Timestamp:  [unsigned long] */
+#define NAVX_REG_TIMESTAMP_L_L      0x12
+#define NAVX_REG_TIMESTAMP_L_H      0x13
+#define NAVX_REG_TIMESTAMP_H_L		0x14
+#define NAVX_REG_TIMESTAMP_H_H		0x15
+
+/* Yaw, Pitch, Roll:  Range: -180.00 to 180.00 [signed hundredths] */
+/* Compass Heading:   Range: 0.00 to 360.00 [unsigned hundredths] */
+/* Altitude in Meters:  In units of meters [16:16] */
+
+#define NAVX_REG_YAW_L 				0x16 /* Lower 8 bits of Yaw     */
+#define NAVX_REG_YAW_H 				0x17 /* Upper 8 bits of Yaw     */
+#define NAVX_REG_PITCH_L 			0x18 /* Lower 8 bits of Pitch   */
+#define NAVX_REG_PITCH_H 			0x19 /* Upper 8 bits of Pitch   */
+#define NAVX_REG_ROLL_L 			0x1A /* Lower 8 bits of Roll    */
+#define NAVX_REG_ROLL_H 			0x1B /* Upper 8 bits of Roll    */
+#define NAVX_REG_HEADING_L 			0x1C /* Lower 8 bits of Heading */
+#define NAVX_REG_HEADING_H 			0x1D /* Upper 8 bits of Heading */
+#define NAVX_REG_FUSED_HEADING_L	0x1E /* Upper 8 bits of Fused Heading */
+#define NAVX_REG_FUSED_HEADING_H	0x1F /* Upper 8 bits of Fused Heading */
+#define NAVX_REG_ALTITUDE_I_L		0x20
+#define NAVX_REG_ALTITUDE_I_H		0x21
+#define NAVX_REG_ALTITUDE_D_L		0x22
+#define NAVX_REG_ALTITUDE_D_H		0x23
+
+/* World-frame Linear Acceleration: In units of +/- G * 1000 [signed thousandths] */
+
+#define NAVX_REG_LINEAR_ACC_X_L		0x24 /* Lower 8 bits of Linear Acceleration X */
+#define NAVX_REG_LINEAR_ACC_X_H		0x25 /* Upper 8 bits of Linear Acceleration X */
+#define NAVX_REG_LINEAR_ACC_Y_L		0x26 /* Lower 8 bits of Linear Acceleration Y */
+#define NAVX_REG_LINEAR_ACC_Y_H		0x27 /* Upper 8 bits of Linear Acceleration Y */
+#define NAVX_REG_LINEAR_ACC_Z_L		0x28 /* Lower 8 bits of Linear Acceleration Z */
+#define NAVX_REG_LINEAR_ACC_Z_H		0x29 /* Upper 8 bits of Linear Acceleration Z */
+
+/* Quaternion:  Range -1 to 1 [signed short ratio] */
+
+#define NAVX_REG_QUAT_W_L 			0x2A /* Lower 8 bits of Quaternion W */
+#define NAVX_REG_QUAT_W_H 			0x2B /* Upper 8 bits of Quaternion W */
+#define NAVX_REG_QUAT_X_L 			0x2C /* Lower 8 bits of Quaternion X */
+#define NAVX_REG_QUAT_X_H 			0x2D /* Upper 8 bits of Quaternion X */
+#define NAVX_REG_QUAT_Y_L 			0x2E /* Lower 8 bits of Quaternion Y */
+#define NAVX_REG_QUAT_Y_H 			0x2F /* Upper 8 bits of Quaternion Y */
+#define NAVX_REG_QUAT_Z_L 			0x30 /* Lower 8 bits of Quaternion Z */
+#define NAVX_REG_QUAT_Z_H 			0x31 /* Upper 8 bits of Quaternion Z */
+
+/**********************************************/
+/* Raw Data Registers                         */
+/**********************************************/
+
+/* Sensor Die Temperature:  Range +/- 150, In units of Centigrade * 100 [signed hundredths float */
+
+#define NAVX_REG_MPU_TEMP_C_L		0x32 /* Lower 8 bits of Temperature */
+#define NAVX_REG_MPU_TEMP_C_H		0x33 /* Upper 8 bits of Temperature */
+
+/* Raw, Calibrated Angular Rotation, in device units.  Value in DPS = units / GYRO_FSR_DPS [signed short] */
+
+#define NAVX_REG_GYRO_X_L			0x34
+#define NAVX_REG_GYRO_X_H			0x35
+#define NAVX_REG_GYRO_Y_L			0x36
+#define NAVX_REG_GYRO_Y_H			0x37
+#define NAVX_REG_GYRO_Z_L			0x38
+#define NAVX_REG_GYRO_Z_H			0x39
+
+/* Raw, Calibrated, Acceleration Data, in device units.  Value in G = units / ACCEL_FSR_G [signed short] */
+
+#define NAVX_REG_ACC_X_L			0x3A
+#define NAVX_REG_ACC_X_H			0x3B
+#define NAVX_REG_ACC_Y_L			0x3C
+#define NAVX_REG_ACC_Y_H			0x3D
+#define NAVX_REG_ACC_Z_L			0x3E
+#define NAVX_REG_ACC_Z_H			0x3F
+
+/* Raw, Calibrated, Un-tilt corrected Magnetometer Data, in device units.  1 unit = 0.15 uTesla [signed short] */
+
+#define NAVX_REG_MAG_X_L			0x40
+#define NAVX_REG_MAG_X_H			0x41
+#define NAVX_REG_MAG_Y_L			0x42
+#define NAVX_REG_MAG_Y_H			0x43
+#define NAVX_REG_MAG_Z_L			0x44
+#define NAVX_REG_MAG_Z_H			0x45
+
+/* Calibrated Pressure in millibars Valid Range:  10.00 Max:  1200.00 [16:16 float]  */
+
+#define NAVX_REG_PRESSURE_IL        0x46
+#define NAVX_REG_PRESSURE_IH        0x47
+#define NAVX_REG_PRESSURE_DL        0x48
+#define NAVX_REG_PRESSURE_DH		0x49
+
+/* Pressure Sensor Die Temperature:  Range +/- 150.00C [signed hundredths] */
+
+#define NAVX_REG_PRESSURE_TEMP_L	0x4A
+#define NAVX_REG_PRESSURE_TEMP_H	0x4B
+
+/**********************************************/
+/* Calibration Registers                      */
+/**********************************************/
+
+/* Yaw Offset: Range -180.00 to 180.00 [signed hundredths] */
+
+#define NAVX_REG_YAW_OFFSET_L		0x4C /* Lower 8 bits of Yaw Offset */
+#define NAVX_REG_YAW_OFFSET_H		0x4D /* Upper 8 bits of Yaw Offset */
+
+/* Quaternion Offset:  Range: -1 to 1 [signed short ratio]  */
+
+#define NAVX_REG_QUAT_OFFSET_W_L 	0x4E /* Lower 8 bits of Quaternion W */
+#define NAVX_REG_QUAT_OFFSET_W_H 	0x4F /* Upper 8 bits of Quaternion W */
+#define NAVX_REG_QUAT_OFFSET_X_L 	0x50 /* Lower 8 bits of Quaternion X */
+#define NAVX_REG_QUAT_OFFSET_X_H 	0x51 /* Upper 8 bits of Quaternion X */
+#define NAVX_REG_QUAT_OFFSET_Y_L 	0x52 /* Lower 8 bits of Quaternion Y */
+#define NAVX_REG_QUAT_OFFSET_Y_H 	0x53 /* Upper 8 bits of Quaternion Y */
+#define NAVX_REG_QUAT_OFFSET_Z_L 	0x54 /* Lower 8 bits of Quaternion Z */
+#define NAVX_REG_QUAT_OFFSET_Z_H 	0x55 /* Upper 8 bits of Quaternion Z */
+
+#define NAVX_REG_LAST NAVX_REG_QUAT_OFFSET_Z_H
+
+/* NAVX_MODEL */
+
+#define NAVX_MODEL_NAVX_MXP							0x32
+
+/* NAVX_CAL_STATUS */
+
+#define NAVX_CAL_STATUS_IMU_CAL_STATE_MASK       	0x03
+#define NAVX_CAL_STATUS_IMU_CAL_INPROGRESS			0x00
+#define NAVX_CAL_STATUS_IMU_CAL_ACCUMULATE			0x01
+#define NAVX_CAL_STATUS_IMU_CAL_COMPLETE			0x02
+
+#define NAVX_CAL_STATUS_MAG_CAL_COMPLETE			0x04
+#define NAVX_CAL_STATUS_BARO_CAL_COMPLETE			0x08
+
+/* NAVX_SELFTEST_STATUS */
+
+#define NAVX_SELFTEST_STATUS_COMPLETE				0x80
+
+#define NAVX_SELFTEST_RESULT_GYRO_PASSED			0x01
+#define NAVX_SELFTEST_RESULT_ACCEL_PASSED			0x02
+#define NAVX_SELFTEST_RESULT_MAG_PASSED				0x04
+#define NAVX_SELFTEST_RESULT_BARO_PASSED			0x08
+
+/* NAVX_OP_STATUS */
+
+#define NAVX_OP_STATUS_INITIALIZING					0x00
+#define NAVX_OP_STATUS_SELFTEST_IN_PROGRESS       	0x01
+#define NAVX_OP_STATUS_ERROR						0x02 /* E.g., Self-test fail, I2C error */
+#define NAVX_OP_STATUS_IMU_AUTOCAL_IN_PROGRESS		0x03
+#define NAVX_OP_STATUS_NORMAL					 	0x04
+
+/* NAVX_SENSOR_STATUS */
+
+#define NAVX_SENSOR_STATUS_MOVING					0x01
+#define NAVX_SENSOR_STATUS_YAW_STABLE				0x02
+#define NAVX_SENSOR_STATUS_MAG_DISTURBANCE			0x04
+#define NAVX_SENSOR_STATUS_ALTITUDE_VALID			0x08
+#define NAVX_SENSOR_STATUS_SEALEVEL_PRESS_SET		0x10
+#define NAVX_SENSOR_STATUS_FUSED_HEADING_VALID		0x20
+
+class IMURegisters
+{
+public:
+	/************************************************************/
+	/* NOTE:                                                    */
+	/* The following functions assume a little-endian processor */
+	/************************************************************/
+
+	static inline uint16_t decodeProtocolUint16( char *uint16_bytes ) {
+		return *((uint16_t *)uint16_bytes);
+	}
+	static inline void encodeProtocolUint16( uint16_t val, char *uint16_bytes) {
+		*((uint16_t *)uint16_bytes) = val;
+	}
+
+	static inline int16_t decodeProtocolInt16( char *int16_bytes ) {
+		return *((int16_t *)int16_bytes);
+	}
+	static inline void encodeProtocolInt16( int16_t val, char *int16_bytes) {
+		*((int16_t *)int16_bytes) = val;
+	}
+
+	/* -327.68 to +327.68 */
+	static inline float decodeProtocolSignedHundredthsFloat( char *uint8_signed_angle_bytes ) {
+		float signed_angle = (float)decodeProtocolUint16(uint8_signed_angle_bytes);
+		signed_angle /= 100;
+		return signed_angle;
+	}
+	static inline void encodeProtocolSignedHundredthsFloat( float input, char *uint8_signed_hundredths_float) {
+		int16_t input_as_int = (int16_t)(input * 100.0f);
+		encodeProtocolInt16(input_as_int,uint8_signed_hundredths_float);
+	}
+
+	static inline s_short_hundred_float encodeSignedHundredthsFloat( float input ) {
+		return (s_short_hundred_float)(input * 100.0f);
+	}
+	static inline u_short_hundred_float encodeUnsignedHundredthsFloat(float input ) {
+		return (u_short_hundred_float)(input * 100.0f);
+	}
+
+	static inline s_short_ratio_float encodeRatioFloat(float input_ratio) {
+		return (s_short_hundred_float)(input_ratio *= 32768.0f);
+	}
+	static inline s_short_thousand_float encodeSignedThousandthsFloat(float input) {
+		return (s_short_thousand_float)(input * 1000.0f);
+	}
+
+	/* 0 to 655.35 */
+	static inline float decodeProtocolUnsignedHundredthsFloat( char *uint8_unsigned_hundredths_float ) {
+		float unsigned_float = (float)decodeProtocolUint16(uint8_unsigned_hundredths_float);
+		unsigned_float /= 100;
+		return unsigned_float;
+	}
+	static inline void encodeProtocolUnsignedHundredthsFloat( float input, char *uint8_unsigned_hundredths_float) {
+		uint16_t input_as_uint = (uint16_t)(input * 100.0f);
+		encodeProtocolUint16(input_as_uint,uint8_unsigned_hundredths_float);
+	}
+
+	/* -32.768 to +32.768 */
+	static inline float decodeProtocolSignedThousandthsFloat( char *uint8_signed_angle_bytes ) {
+		float signed_angle = (float)decodeProtocolUint16(uint8_signed_angle_bytes);
+		signed_angle /= 1000;
+		return signed_angle;
+	}
+	static inline void encodeProtocolSignedThousandthsFloat( float input, char *uint8_signed_thousandths_float) {
+		int16_t input_as_int = (int16_t)(input * 1000.0f);
+		encodeProtocolInt16(input_as_int,uint8_signed_thousandths_float);
+	}
+
+	/* In units of -1 to 1, multiplied by 16384 */
+	static inline float decodeProtocolRatio( char *uint8_ratio ) {
+		float ratio = (float)decodeProtocolUint16(uint8_ratio);
+		ratio /= 32768.0f;
+		return ratio;
+	}
+	static inline void encodeProtocolRatio( float ratio, char *uint8_ratio ) {
+		ratio *= 32768.0f;
+		encodeProtocolInt16(ratio,uint8_ratio);
+	}
+
+	/* <int16>.<uint16> (-32768.9999 to 32767.9999) */
+	static float decodeProtocol1616Float( char *uint8_16_16_bytes ) {
+		float result = (float)decodeProtocolInt16(uint8_16_16_bytes);
+		float decimal_portion = ((float)decodeProtocolUint16(uint8_16_16_bytes + sizeof(uint16_t))) / 65535.0f; /* TODO:  IS this off by one? */
+		if ( result >= 0.0 ) {
+			result += decimal_portion;
+		} else {
+			result -= decimal_portion;
+		}
+		return result;
+	}
+	static void encodeProtocol1616Float( float val, char *uint8_16_16_bytes ) {
+
+		int16_t int_portion = (int)val;
+		float decimal_portion = val - (float)int_portion;
+		uint16_t decimal_as_int = (uint16_t)(decimal_portion * 65535.0f); /* TODO:  IS this off by one? */
+		encodeProtocolInt16(int_portion, uint8_16_16_bytes);
+		encodeProtocolUint16(decimal_as_int, uint8_16_16_bytes + sizeof(uint16_t));
+	}
+
+#define CRC7_POLY 0x91
+
+	static uint8_t getCRC(uint8_t message[], uint8_t length)
+	{
+	  uint8_t i, j, crc = 0;
+
+	  for (i = 0; i < length; i++)
+	  {
+	    crc ^= message[i];
+	    for (j = 0; j < 8; j++)
+	    {
+	      if (crc & 1) {
+	    	  crc ^= CRC7_POLY;
+	      }
+	      crc >>= 1;
+	    }
+	  }
+	  return crc;
+	}
+};
+
+
+#endif /* IMU_REGISTERS_H_ */


### PR DESCRIPTION
Added object navX MXP Inertial Measurement Unit (IMU) to allow field
oriented mecanum drive using built in gyro.
Added joystick buttons 8 and 12 to determine whether to use the IMU gyro
in mecanum drive.
Also adjusted configuration of elevator POT range, target settings.
These are estimated need to be validated.
Lastly, labeled various configuration options with comment "//
Configure" to help find tuning components more easily.
